### PR TITLE
Sync response models and OAuth scopes with current API schema

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/authorization/Scope.java
+++ b/src/main/java/pl/teksusik/kick4j/authorization/Scope.java
@@ -4,10 +4,14 @@ public enum Scope {
     USER_READ("user:read"),
     CHANNEL_READ("channel:read"),
     CHANNEL_WRITE("channel:write"),
+    CHANNEL_REWARDS_READ("channel:rewards:read"),
+    CHANNEL_REWARDS_WRITE("channel:rewards:write"),
     CHAT_WRITE("chat:write"),
     STREAMKEY_READ("streamkey:read"),
     EVENTS_SUBSCRIBE("events:subscribe"),
-    MODERATION_BAN("moderation:ban");
+    MODERATION_BAN("moderation:ban"),
+    MODERATION_CHAT_MESSAGE_MANAGE("moderation:chat_message:manage"),
+    KICKS_READ("kicks:read");
 
     private final String scope;
 

--- a/src/main/java/pl/teksusik/kick4j/channels/Channel.java
+++ b/src/main/java/pl/teksusik/kick4j/channels/Channel.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import pl.teksusik.kick4j.categories.Category;
 
 public class Channel {
+    private final Integer activeSubscribersCount;
     private final String bannerPicture;
     private final Integer broadcasterUserId;
+    private final Integer canceledSubscribersCount;
     private final Category category;
     private final String channelDescription;
     private final String slug;
@@ -14,20 +16,32 @@ public class Channel {
     private final String streamTitle;
 
     @JsonCreator
-    public Channel(@JsonProperty("banner_picture") String bannerPicture,
+    public Channel(@JsonProperty("active_subscribers_count") Integer activeSubscribersCount,
+                   @JsonProperty("banner_picture") String bannerPicture,
                    @JsonProperty("broadcaster_user_id") Integer broadcasterUserId,
+                   @JsonProperty("canceled_subscribers_count") Integer canceledSubscribersCount,
                    @JsonProperty("category") Category category,
                    @JsonProperty("channel_description") String channelDescription,
                    @JsonProperty("slug") String slug,
                    @JsonProperty("stream") StreamInformation stream,
                    @JsonProperty("stream_title") String streamTitle) {
+        this.activeSubscribersCount = activeSubscribersCount;
         this.bannerPicture = bannerPicture;
         this.broadcasterUserId = broadcasterUserId;
+        this.canceledSubscribersCount = canceledSubscribersCount;
         this.category = category;
         this.channelDescription = channelDescription;
         this.slug = slug;
         this.stream = stream;
         this.streamTitle = streamTitle;
+    }
+
+    public Integer getActiveSubscribersCount() {
+        return activeSubscribersCount;
+    }
+
+    public Integer getCanceledSubscribersCount() {
+        return canceledSubscribersCount;
     }
 
     public String getBannerPicture() {

--- a/src/main/java/pl/teksusik/kick4j/channels/StreamInformation.java
+++ b/src/main/java/pl/teksusik/kick4j/channels/StreamInformation.java
@@ -3,7 +3,10 @@ package pl.teksusik.kick4j.channels;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 public class StreamInformation {
+    private final List<String> customTags;
     private final Boolean isLive;
     private final Boolean isMature;
     private final String key;
@@ -14,7 +17,8 @@ public class StreamInformation {
     private final Integer viewerCount;
 
     @JsonCreator
-    public StreamInformation(@JsonProperty("is_live") Boolean isLive,
+    public StreamInformation(@JsonProperty("custom_tags") List<String> customTags,
+                             @JsonProperty("is_live") Boolean isLive,
                              @JsonProperty("is_mature") Boolean isMature,
                              @JsonProperty("key") String key,
                              @JsonProperty("language") String language,
@@ -22,6 +26,7 @@ public class StreamInformation {
                              @JsonProperty("thumbnail") String thumbnail,
                              @JsonProperty("url") String url,
                              @JsonProperty("viewer_count") Integer viewerCount) {
+        this.customTags = customTags;
         this.isLive = isLive;
         this.isMature = isMature;
         this.key = key;
@@ -30,6 +35,10 @@ public class StreamInformation {
         this.thumbnail = thumbnail;
         this.url = url;
         this.viewerCount = viewerCount;
+    }
+
+    public List<String> getCustomTags() {
+        return customTags;
     }
 
     public Boolean isLive() {

--- a/src/main/java/pl/teksusik/kick4j/livestreams/Livestream.java
+++ b/src/main/java/pl/teksusik/kick4j/livestreams/Livestream.java
@@ -4,12 +4,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import pl.teksusik.kick4j.categories.Category;
 
+import java.util.List;
+
 public class Livestream {
     private final Integer broadcasterUserId;
     private final Category category;
     private final Integer channelId;
+    private final List<String> customTags;
     private final Boolean hasMatureContent;
     private final String language;
+    private final String profilePicture;
     private final String slug;
     private final String startedAt;
     private final String streamTitle;
@@ -20,8 +24,10 @@ public class Livestream {
     public Livestream(@JsonProperty("broadcaster_user_id") Integer broadcasterUserId,
                       @JsonProperty("category") Category category,
                       @JsonProperty("channel_id") Integer channelId,
+                      @JsonProperty("custom_tags") List<String> customTags,
                       @JsonProperty("has_mature_content") Boolean hasMatureContent,
                       @JsonProperty("language") String language,
+                      @JsonProperty("profile_picture") String profilePicture,
                       @JsonProperty("slug") String slug,
                       @JsonProperty("started_at") String startedAt,
                       @JsonProperty("stream_title") String streamTitle,
@@ -30,8 +36,10 @@ public class Livestream {
         this.broadcasterUserId = broadcasterUserId;
         this.category = category;
         this.channelId = channelId;
+        this.customTags = customTags;
         this.hasMatureContent = hasMatureContent;
         this.language = language;
+        this.profilePicture = profilePicture;
         this.slug = slug;
         this.startedAt = startedAt;
         this.streamTitle = streamTitle;
@@ -51,12 +59,20 @@ public class Livestream {
         return channelId;
     }
 
+    public List<String> getCustomTags() {
+        return customTags;
+    }
+
     public Boolean getHasMatureContent() {
         return hasMatureContent;
     }
 
     public String getLanguage() {
         return language;
+    }
+
+    public String getProfilePicture() {
+        return profilePicture;
     }
 
     public String getSlug() {


### PR DESCRIPTION
Closes #13

Foundational, additive sync with the current Kick OpenAPI spec (`api.kick.com/swagger/doc.yaml`). No behaviour changes to existing calls — only fields the API already returns but the library silently dropped (previously logged as `Ignored property` warnings), plus the missing scope values.

## Model fields added
- **`Channel`** (`endpoints.GetChannel`): `active_subscribers_count`, `canceled_subscribers_count`
- **`StreamInformation`** (`endpoints.Stream`): `custom_tags`
- **`Livestream`** (v1 `endpoints.LivestreamWithCategory`): `custom_tags`, `profile_picture`

## Scopes added (`Scope.java`)
- `channel:rewards:read`
- `channel:rewards:write`
- `moderation:chat_message:manage`
- `kicks:read`

## Tests
No new tests in this PR. Existing tests cover events, which have full documented payloads; the response DTOs here have no full documented example response to test against, so tests are deferred.

`./gradlew clean build` passes locally.

> Unblocks #14 (Channel Rewards), #15 (KICKs) and #16 (chat delete), which depend on the new scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)