### PR TITLE
Implement Channel Rewards API (channel points)

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/KickClient.java
+++ b/src/main/java/pl/teksusik/kick4j/KickClient.java
@@ -24,6 +24,7 @@ import pl.teksusik.kick4j.events.handler.KickSignatureVerifier;
 import pl.teksusik.kick4j.livestreams.LivestreamsClient;
 import pl.teksusik.kick4j.moderation.ModerationClient;
 import pl.teksusik.kick4j.publicKey.PublicKeyClient;
+import pl.teksusik.kick4j.rewards.ChannelRewardsClient;
 import pl.teksusik.kick4j.users.UsersClient;
 
 import java.io.IOException;
@@ -35,6 +36,7 @@ public class KickClient {
     private final CategoriesClient categoriesClient;
     private final UsersClient usersClient;
     private final ChannelsClient channelsClient;
+    private final ChannelRewardsClient channelRewardsClient;
     private final ChatClient chatClient;
     private final ModerationClient moderationClient;
     private final LivestreamsClient livestreamsClient;
@@ -73,6 +75,7 @@ public class KickClient {
         this.categoriesClient = new CategoriesClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.usersClient = new UsersClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.channelsClient = new ChannelsClient(httpClient, objectMapper, configuration, this.authorizationClient);
+        this.channelRewardsClient = new ChannelRewardsClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.chatClient = new ChatClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.moderationClient = new ModerationClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.livestreamsClient = new LivestreamsClient(httpClient, objectMapper, configuration, this.authorizationClient);
@@ -116,6 +119,10 @@ public class KickClient {
 
     public ChannelsClient channels() {
         return channelsClient;
+    }
+
+    public ChannelRewardsClient channelRewards() {
+        return channelRewardsClient;
     }
 
     public ChatClient chat() {

--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -24,6 +24,11 @@ public final class KickConfiguration {
     private final String livestreamsStats;
     private final String publicKey;
     private final String events;
+    private final String channelsRewards;
+    private final String channelsRewardsId;
+    private final String channelsRewardsRedemptions;
+    private final String channelsRewardsRedemptionsAccept;
+    private final String channelsRewardsRedemptionsReject;
 
     private KickConfiguration(Builder builder) {
         this.tokenStore = builder.tokenStore;
@@ -45,6 +50,11 @@ public final class KickConfiguration {
         this.livestreamsStats = builder.livestreamsStats;
         this.publicKey = builder.publicKey;
         this.events = builder.events;
+        this.channelsRewards = builder.channelsRewards;
+        this.channelsRewardsId = builder.channelsRewardsId;
+        this.channelsRewardsRedemptions = builder.channelsRewardsRedemptions;
+        this.channelsRewardsRedemptionsAccept = builder.channelsRewardsRedemptionsAccept;
+        this.channelsRewardsRedemptionsReject = builder.channelsRewardsRedemptionsReject;
     }
 
     public static Builder builder() {
@@ -127,6 +137,26 @@ public final class KickConfiguration {
         return events;
     }
 
+    public String getChannelsRewards() {
+        return channelsRewards;
+    }
+
+    public String getChannelsRewardsId() {
+        return channelsRewardsId;
+    }
+
+    public String getChannelsRewardsRedemptions() {
+        return channelsRewardsRedemptions;
+    }
+
+    public String getChannelsRewardsRedemptionsAccept() {
+        return channelsRewardsRedemptionsAccept;
+    }
+
+    public String getChannelsRewardsRedemptionsReject() {
+        return channelsRewardsRedemptionsReject;
+    }
+
     public static final class Builder {
         private RefreshTokenStore tokenStore;
         private String clientId;
@@ -147,6 +177,11 @@ public final class KickConfiguration {
         private String livestreamsStats = "/livestreams/stats";
         private String publicKey = "/public-key";
         private String events = "/events/subscriptions";
+        private String channelsRewards = "/channels/rewards";
+        private String channelsRewardsId = "/channels/rewards/{id}";
+        private String channelsRewardsRedemptions = "/channels/rewards/redemptions";
+        private String channelsRewardsRedemptionsAccept = "/channels/rewards/redemptions/accept";
+        private String channelsRewardsRedemptionsReject = "/channels/rewards/redemptions/reject";
 
         public Builder tokenStore(RefreshTokenStore tokenStore) {
             this.tokenStore = tokenStore;
@@ -240,6 +275,31 @@ public final class KickConfiguration {
 
         public Builder events(String events) {
             this.events = events;
+            return this;
+        }
+
+        public Builder channelsRewards(String channelsRewards) {
+            this.channelsRewards = channelsRewards;
+            return this;
+        }
+
+        public Builder channelsRewardsId(String channelsRewardsId) {
+            this.channelsRewardsId = channelsRewardsId;
+            return this;
+        }
+
+        public Builder channelsRewardsRedemptions(String channelsRewardsRedemptions) {
+            this.channelsRewardsRedemptions = channelsRewardsRedemptions;
+            return this;
+        }
+
+        public Builder channelsRewardsRedemptionsAccept(String channelsRewardsRedemptionsAccept) {
+            this.channelsRewardsRedemptionsAccept = channelsRewardsRedemptionsAccept;
+            return this;
+        }
+
+        public Builder channelsRewardsRedemptionsReject(String channelsRewardsRedemptionsReject) {
+            this.channelsRewardsRedemptionsReject = channelsRewardsRedemptionsReject;
             return this;
         }
 

--- a/src/main/java/pl/teksusik/kick4j/rewards/ChannelReward.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/ChannelReward.java
@@ -1,0 +1,73 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ChannelReward {
+    private final String backgroundColor;
+    private final Integer cost;
+    private final String description;
+    private final String id;
+    private final Boolean isEnabled;
+    private final Boolean isPaused;
+    private final Boolean isUserInputRequired;
+    private final Boolean shouldRedemptionsSkipRequestQueue;
+    private final String title;
+
+    @JsonCreator
+    public ChannelReward(@JsonProperty("background_color") String backgroundColor,
+                         @JsonProperty("cost") Integer cost,
+                         @JsonProperty("description") String description,
+                         @JsonProperty("id") String id,
+                         @JsonProperty("is_enabled") Boolean isEnabled,
+                         @JsonProperty("is_paused") Boolean isPaused,
+                         @JsonProperty("is_user_input_required") Boolean isUserInputRequired,
+                         @JsonProperty("should_redemptions_skip_request_queue") Boolean shouldRedemptionsSkipRequestQueue,
+                         @JsonProperty("title") String title) {
+        this.backgroundColor = backgroundColor;
+        this.cost = cost;
+        this.description = description;
+        this.id = id;
+        this.isEnabled = isEnabled;
+        this.isPaused = isPaused;
+        this.isUserInputRequired = isUserInputRequired;
+        this.shouldRedemptionsSkipRequestQueue = shouldRedemptionsSkipRequestQueue;
+        this.title = title;
+    }
+
+    public String getBackgroundColor() {
+        return backgroundColor;
+    }
+
+    public Integer getCost() {
+        return cost;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public Boolean isPaused() {
+        return isPaused;
+    }
+
+    public Boolean isUserInputRequired() {
+        return isUserInputRequired;
+    }
+
+    public Boolean shouldRedemptionsSkipRequestQueue() {
+        return shouldRedemptionsSkipRequestQueue;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/ChannelRewardRedemption.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/ChannelRewardRedemption.java
@@ -1,0 +1,47 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+public class ChannelRewardRedemption {
+    private final String id;
+    private final Instant redeemedAt;
+    private final Redeemer redeemer;
+    private final RedemptionStatus status;
+    private final String userInput;
+
+    @JsonCreator
+    public ChannelRewardRedemption(@JsonProperty("id") String id,
+                                   @JsonProperty("redeemed_at") Instant redeemedAt,
+                                   @JsonProperty("redeemer") Redeemer redeemer,
+                                   @JsonProperty("status") RedemptionStatus status,
+                                   @JsonProperty("user_input") String userInput) {
+        this.id = id;
+        this.redeemedAt = redeemedAt;
+        this.redeemer = redeemer;
+        this.status = status;
+        this.userInput = userInput;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Instant getRedeemedAt() {
+        return redeemedAt;
+    }
+
+    public Redeemer getRedeemer() {
+        return redeemer;
+    }
+
+    public RedemptionStatus getStatus() {
+        return status;
+    }
+
+    public String getUserInput() {
+        return userInput;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/ChannelRewardsClient.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/ChannelRewardsClient.java
@@ -1,0 +1,97 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import pl.teksusik.kick4j.KickConfiguration;
+import pl.teksusik.kick4j.api.ApiClient;
+import pl.teksusik.kick4j.authorization.AuthorizationClient;
+
+import java.net.http.HttpClient;
+import java.util.List;
+import java.util.Map;
+
+public class ChannelRewardsClient extends ApiClient {
+    public ChannelRewardsClient(HttpClient httpClient, ObjectMapper mapper, KickConfiguration configuration, AuthorizationClient authorization) {
+        super(httpClient, mapper, configuration, authorization);
+    }
+
+    /**
+     * Lists channel rewards for the authenticated broadcaster's channel (up to 15).
+     */
+    public List<ChannelReward> getRewards() {
+        return this.get(this.configuration.getChannelsRewards())
+                .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Creates a channel reward. A maximum of 15 rewards can exist per channel.
+     */
+    public ChannelReward createReward(CreateChannelRewardRequest request) {
+        return this.post(this.configuration.getChannelsRewards())
+                .body(request)
+                .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Updates an existing channel reward.
+     */
+    public ChannelReward updateReward(String rewardId, UpdateChannelRewardRequest request) {
+        return this.patch(this.configuration.getChannelsRewardsId())
+                .pathParams(Map.of("id", rewardId))
+                .body(request)
+                .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Deletes a channel reward. Only the app that created the reward can delete it.
+     */
+    public void deleteReward(String rewardId) {
+        this.delete(this.configuration.getChannelsRewardsId())
+                .pathParams(Map.of("id", rewardId))
+                .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Lists reward redemptions, grouped by reward. Defaults to pending redemptions.
+     */
+    public List<RedemptionsByReward> getRedemptions() {
+        return this.getRedemptions(GetRedemptionsRequest.builder().build());
+    }
+
+    /**
+     * Lists reward redemptions, grouped by reward, using the provided filters.
+     */
+    public List<RedemptionsByReward> getRedemptions(GetRedemptionsRequest request) {
+        return this.get(this.configuration.getChannelsRewardsRedemptions())
+                .queryParams(request)
+                .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Accepts pending redemptions (up to 25 unique IDs per request).
+     * Returns only the redemptions that failed to be accepted.
+     */
+    public List<FailedRedemption> acceptRedemptions(List<String> ids) {
+        return this.post(this.configuration.getChannelsRewardsRedemptionsAccept())
+                .body(Map.of("ids", ids))
+                .send(new TypeReference<>() {});
+    }
+
+    public List<FailedRedemption> acceptRedemptions(String... ids) {
+        return this.acceptRedemptions(List.of(ids));
+    }
+
+    /**
+     * Rejects pending redemptions (up to 25 unique IDs per request).
+     * Returns only the redemptions that failed to be rejected.
+     */
+    public List<FailedRedemption> rejectRedemptions(List<String> ids) {
+        return this.post(this.configuration.getChannelsRewardsRedemptionsReject())
+                .body(Map.of("ids", ids))
+                .send(new TypeReference<>() {});
+    }
+
+    public List<FailedRedemption> rejectRedemptions(String... ids) {
+        return this.rejectRedemptions(List.of(ids));
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/CreateChannelRewardRequest.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/CreateChannelRewardRequest.java
@@ -1,0 +1,123 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateChannelRewardRequest {
+    @JsonProperty("background_color")
+    private final String backgroundColor;
+    @JsonProperty("cost")
+    private final Integer cost;
+    @JsonProperty("description")
+    private final String description;
+    @JsonProperty("is_enabled")
+    private final Boolean isEnabled;
+    @JsonProperty("is_user_input_required")
+    private final Boolean isUserInputRequired;
+    @JsonProperty("should_redemptions_skip_request_queue")
+    private final Boolean shouldRedemptionsSkipRequestQueue;
+    @JsonProperty("title")
+    private final String title;
+
+    public CreateChannelRewardRequest(String backgroundColor, Integer cost, String description, Boolean isEnabled,
+                                      Boolean isUserInputRequired, Boolean shouldRedemptionsSkipRequestQueue, String title) {
+        this.backgroundColor = backgroundColor;
+        this.cost = cost;
+        this.description = description;
+        this.isEnabled = isEnabled;
+        this.isUserInputRequired = isUserInputRequired;
+        this.shouldRedemptionsSkipRequestQueue = shouldRedemptionsSkipRequestQueue;
+        this.title = title;
+    }
+
+    public String getBackgroundColor() {
+        return backgroundColor;
+    }
+
+    public Integer getCost() {
+        return cost;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+
+    public Boolean getIsUserInputRequired() {
+        return isUserInputRequired;
+    }
+
+    public Boolean getShouldRedemptionsSkipRequestQueue() {
+        return shouldRedemptionsSkipRequestQueue;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String backgroundColor;
+        private Integer cost;
+        private String description;
+        private Boolean isEnabled;
+        private Boolean isUserInputRequired;
+        private Boolean shouldRedemptionsSkipRequestQueue;
+        private String title;
+
+        public Builder backgroundColor(String backgroundColor) {
+            this.backgroundColor = backgroundColor;
+            return this;
+        }
+
+        public Builder cost(Integer cost) {
+            this.cost = cost;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            return this;
+        }
+
+        public Builder isUserInputRequired(Boolean isUserInputRequired) {
+            this.isUserInputRequired = isUserInputRequired;
+            return this;
+        }
+
+        public Builder shouldRedemptionsSkipRequestQueue(Boolean shouldRedemptionsSkipRequestQueue) {
+            this.shouldRedemptionsSkipRequestQueue = shouldRedemptionsSkipRequestQueue;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public CreateChannelRewardRequest build() {
+            if (title == null) {
+                throw new IllegalStateException("Title is required");
+            }
+
+            if (cost == null) {
+                throw new IllegalStateException("Cost is required");
+            }
+
+            return new CreateChannelRewardRequest(backgroundColor, cost, description, isEnabled,
+                    isUserInputRequired, shouldRedemptionsSkipRequestQueue, title);
+        }
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/FailedRedemption.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/FailedRedemption.java
@@ -1,0 +1,24 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FailedRedemption {
+    private final String id;
+    private final FailedRedemptionReason reason;
+
+    @JsonCreator
+    public FailedRedemption(@JsonProperty("id") String id,
+                            @JsonProperty("reason") FailedRedemptionReason reason) {
+        this.id = id;
+        this.reason = reason;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public FailedRedemptionReason getReason() {
+        return reason;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/FailedRedemptionReason.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/FailedRedemptionReason.java
@@ -1,0 +1,5 @@
+package pl.teksusik.kick4j.rewards;
+
+public enum FailedRedemptionReason {
+    UNKNOWN, NOT_PENDING, NOT_FOUND, NOT_OWNED
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/GetRedemptionsRequest.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/GetRedemptionsRequest.java
@@ -1,0 +1,83 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Filters for listing channel reward redemptions.
+ * <p>
+ * Note: when filtering by redemption {@code ids}, no other filter may be provided.
+ * The {@code cursor} lets callers page manually; the API's {@code next_cursor} is not
+ * surfaced by the response models yet (pending generic pagination support).
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetRedemptionsRequest {
+    @JsonProperty("reward_id")
+    private final String rewardId;
+    @JsonProperty("status")
+    private final RedemptionStatus status;
+    @JsonProperty("id")
+    private final List<String> ids;
+    @JsonProperty("cursor")
+    private final String cursor;
+
+    public GetRedemptionsRequest(String rewardId, RedemptionStatus status, List<String> ids, String cursor) {
+        this.rewardId = rewardId;
+        this.status = status;
+        this.ids = ids;
+        this.cursor = cursor;
+    }
+
+    public String getRewardId() {
+        return rewardId;
+    }
+
+    public RedemptionStatus getStatus() {
+        return status;
+    }
+
+    public List<String> getIds() {
+        return ids;
+    }
+
+    public String getCursor() {
+        return cursor;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String rewardId;
+        private RedemptionStatus status;
+        private List<String> ids;
+        private String cursor;
+
+        public Builder rewardId(String rewardId) {
+            this.rewardId = rewardId;
+            return this;
+        }
+
+        public Builder status(RedemptionStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder ids(List<String> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        public Builder cursor(String cursor) {
+            this.cursor = cursor;
+            return this;
+        }
+
+        public GetRedemptionsRequest build() {
+            return new GetRedemptionsRequest(rewardId, status, ids, cursor);
+        }
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/MinimalChannelReward.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/MinimalChannelReward.java
@@ -1,0 +1,52 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MinimalChannelReward {
+    private final Boolean canManage;
+    private final Long cost;
+    private final String description;
+    private final String id;
+    private final Boolean isDeleted;
+    private final String title;
+
+    @JsonCreator
+    public MinimalChannelReward(@JsonProperty("can_manage") Boolean canManage,
+                                @JsonProperty("cost") Long cost,
+                                @JsonProperty("description") String description,
+                                @JsonProperty("id") String id,
+                                @JsonProperty("is_deleted") Boolean isDeleted,
+                                @JsonProperty("title") String title) {
+        this.canManage = canManage;
+        this.cost = cost;
+        this.description = description;
+        this.id = id;
+        this.isDeleted = isDeleted;
+        this.title = title;
+    }
+
+    public Boolean getCanManage() {
+        return canManage;
+    }
+
+    public Long getCost() {
+        return cost;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Boolean getIsDeleted() {
+        return isDeleted;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/Redeemer.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/Redeemer.java
@@ -1,0 +1,17 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Redeemer {
+    private final Long userId;
+
+    @JsonCreator
+    public Redeemer(@JsonProperty("user_id") Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/RedemptionStatus.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/RedemptionStatus.java
@@ -1,0 +1,18 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum RedemptionStatus {
+    PENDING, ACCEPTED, REJECTED;
+
+    @JsonValue
+    public String toValue() {
+        return name().toLowerCase();
+    }
+
+    @JsonCreator
+    public static RedemptionStatus fromValue(String value) {
+        return valueOf(value.toUpperCase());
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/RedemptionsByReward.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/RedemptionsByReward.java
@@ -1,0 +1,26 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class RedemptionsByReward {
+    private final List<ChannelRewardRedemption> redemptions;
+    private final MinimalChannelReward reward;
+
+    @JsonCreator
+    public RedemptionsByReward(@JsonProperty("redemptions") List<ChannelRewardRedemption> redemptions,
+                               @JsonProperty("reward") MinimalChannelReward reward) {
+        this.redemptions = redemptions;
+        this.reward = reward;
+    }
+
+    public List<ChannelRewardRedemption> getRedemptions() {
+        return redemptions;
+    }
+
+    public MinimalChannelReward getReward() {
+        return reward;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/rewards/UpdateChannelRewardRequest.java
+++ b/src/main/java/pl/teksusik/kick4j/rewards/UpdateChannelRewardRequest.java
@@ -1,0 +1,129 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UpdateChannelRewardRequest {
+    @JsonProperty("background_color")
+    private final String backgroundColor;
+    @JsonProperty("cost")
+    private final Integer cost;
+    @JsonProperty("description")
+    private final String description;
+    @JsonProperty("is_enabled")
+    private final Boolean isEnabled;
+    @JsonProperty("is_paused")
+    private final Boolean isPaused;
+    @JsonProperty("is_user_input_required")
+    private final Boolean isUserInputRequired;
+    @JsonProperty("should_redemptions_skip_request_queue")
+    private final Boolean shouldRedemptionsSkipRequestQueue;
+    @JsonProperty("title")
+    private final String title;
+
+    public UpdateChannelRewardRequest(String backgroundColor, Integer cost, String description, Boolean isEnabled,
+                                      Boolean isPaused, Boolean isUserInputRequired,
+                                      Boolean shouldRedemptionsSkipRequestQueue, String title) {
+        this.backgroundColor = backgroundColor;
+        this.cost = cost;
+        this.description = description;
+        this.isEnabled = isEnabled;
+        this.isPaused = isPaused;
+        this.isUserInputRequired = isUserInputRequired;
+        this.shouldRedemptionsSkipRequestQueue = shouldRedemptionsSkipRequestQueue;
+        this.title = title;
+    }
+
+    public String getBackgroundColor() {
+        return backgroundColor;
+    }
+
+    public Integer getCost() {
+        return cost;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Boolean getIsEnabled() {
+        return isEnabled;
+    }
+
+    public Boolean getIsPaused() {
+        return isPaused;
+    }
+
+    public Boolean getIsUserInputRequired() {
+        return isUserInputRequired;
+    }
+
+    public Boolean getShouldRedemptionsSkipRequestQueue() {
+        return shouldRedemptionsSkipRequestQueue;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String backgroundColor;
+        private Integer cost;
+        private String description;
+        private Boolean isEnabled;
+        private Boolean isPaused;
+        private Boolean isUserInputRequired;
+        private Boolean shouldRedemptionsSkipRequestQueue;
+        private String title;
+
+        public Builder backgroundColor(String backgroundColor) {
+            this.backgroundColor = backgroundColor;
+            return this;
+        }
+
+        public Builder cost(Integer cost) {
+            this.cost = cost;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder isEnabled(Boolean isEnabled) {
+            this.isEnabled = isEnabled;
+            return this;
+        }
+
+        public Builder isPaused(Boolean isPaused) {
+            this.isPaused = isPaused;
+            return this;
+        }
+
+        public Builder isUserInputRequired(Boolean isUserInputRequired) {
+            this.isUserInputRequired = isUserInputRequired;
+            return this;
+        }
+
+        public Builder shouldRedemptionsSkipRequestQueue(Boolean shouldRedemptionsSkipRequestQueue) {
+            this.shouldRedemptionsSkipRequestQueue = shouldRedemptionsSkipRequestQueue;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public UpdateChannelRewardRequest build() {
+            return new UpdateChannelRewardRequest(backgroundColor, cost, description, isEnabled, isPaused,
+                    isUserInputRequired, shouldRedemptionsSkipRequestQueue, title);
+        }
+    }
+}

--- a/src/test/java/pl/teksusik/kick4j/rewards/ChannelRewardsRequestTest.java
+++ b/src/test/java/pl/teksusik/kick4j/rewards/ChannelRewardsRequestTest.java
@@ -1,0 +1,67 @@
+package pl.teksusik.kick4j.rewards;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies serialization of our own request DTOs (JSON key names and query-param mapping),
+ * not any documented API response payload.
+ */
+public class ChannelRewardsRequestTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    public void create_request_serializes_snake_case_keys_and_omits_unset_fields() {
+        CreateChannelRewardRequest request = CreateChannelRewardRequest.builder()
+                .title("Song Request")
+                .cost(100)
+                .backgroundColor("#00e701")
+                .build();
+
+        Map<String, Object> json = MAPPER.convertValue(request, new TypeReference<>() {});
+
+        assertEquals("Song Request", json.get("title"));
+        assertEquals(100, json.get("cost"));
+        assertEquals("#00e701", json.get("background_color"));
+        // Unset optional fields must be omitted so the server applies its defaults.
+        assertFalse(json.containsKey("description"));
+        assertFalse(json.containsKey("is_enabled"));
+        assertFalse(json.containsKey("should_redemptions_skip_request_queue"));
+    }
+
+    @Test
+    public void get_redemptions_request_maps_ids_to_id_and_status_to_lowercase() {
+        GetRedemptionsRequest request = GetRedemptionsRequest.builder()
+                .status(RedemptionStatus.PENDING)
+                .ids(List.of("01A", "01B"))
+                .build();
+
+        Map<String, Object> query = MAPPER.convertValue(request, new TypeReference<>() {});
+
+        // The query param is "id", not "ids".
+        assertEquals(List.of("01A", "01B"), query.get("id"));
+        assertFalse(query.containsKey("ids"));
+        assertEquals("pending", query.get("status"));
+        assertFalse(query.containsKey("reward_id"));
+        assertFalse(query.containsKey("cursor"));
+    }
+
+    @Test
+    public void create_request_requires_title_and_cost() {
+        boolean thrown = false;
+        try {
+            CreateChannelRewardRequest.builder().title("Only title").build();
+        } catch (IllegalStateException exception) {
+            thrown = true;
+        }
+        assertTrue(thrown);
+    }
+}


### PR DESCRIPTION
Closes #14

Adds a new `ChannelRewardsClient` (accessible via `kick.channelRewards()`) covering the full channel-points surface, wired into `KickClient` with paths in `KickConfiguration`.

## Endpoints
| Method | Path | Method on client |
|---|---|---|
| GET | `/channels/rewards` | `getRewards()` |
| POST | `/channels/rewards` | `createReward(CreateChannelRewardRequest)` |
| PATCH | `/channels/rewards/{id}` | `updateReward(id, UpdateChannelRewardRequest)` |
| DELETE | `/channels/rewards/{id}` | `deleteReward(id)` |
| GET | `/channels/rewards/redemptions` | `getRedemptions([GetRedemptionsRequest])` |
| POST | `/channels/rewards/redemptions/accept` | `acceptRedemptions(ids)` |
| POST | `/channels/rewards/redemptions/reject` | `rejectRedemptions(ids)` |

## Models
`ChannelReward`, `MinimalChannelReward`, `ChannelRewardRedemption`, `RedemptionsByReward`, `Redeemer`, `FailedRedemption`, plus `RedemptionStatus` and `FailedRedemptionReason` enums. Request builders `CreateChannelRewardRequest` (requires `cost`+`title`), `UpdateChannelRewardRequest`, `GetRedemptionsRequest`.

## Notes / decisions
- **Redemptions are grouped by reward** (`RedemptionsByReward`), matching the spec's `PaginatedResponse-endpoints_RedemptionsByReward`.
- **Pagination**: the API returns a `next_cursor`, but the current `ApiClient` only unwraps `data`. Callers can pass a `cursor` filter to page manually; surfacing `next_cursor` is deferred to the generic pagination work in #18/#19.
- Accept/Reject return only the **failed** redemptions with a reason code (`UNKNOWN`/`NOT_PENDING`/`NOT_FOUND`/`NOT_OWNED`).
- Scopes `channel:rewards:read/write` came from #13.

## Tests
Per the agreed convention, **no fabricated response payloads**. Added `ChannelRewardsRequestTest`, which asserts serialization of our own request DTOs — snake_case keys, omission of unset fields, and the `ids`→`id` query-param mapping. `./gradlew clean build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)