### PR TITLE
Implement KICKs leaderboard API client

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/KickClient.java
+++ b/src/main/java/pl/teksusik/kick4j/KickClient.java
@@ -21,6 +21,7 @@ import pl.teksusik.kick4j.events.EventsClient;
 import pl.teksusik.kick4j.events.handler.BuiltInKickWebhookHandler;
 import pl.teksusik.kick4j.events.handler.KickEventDispatcher;
 import pl.teksusik.kick4j.events.handler.KickSignatureVerifier;
+import pl.teksusik.kick4j.kicks.KicksClient;
 import pl.teksusik.kick4j.livestreams.LivestreamsClient;
 import pl.teksusik.kick4j.moderation.ModerationClient;
 import pl.teksusik.kick4j.publicKey.PublicKeyClient;
@@ -40,6 +41,7 @@ public class KickClient {
     private final ChatClient chatClient;
     private final ModerationClient moderationClient;
     private final LivestreamsClient livestreamsClient;
+    private final KicksClient kicksClient;
     private final PublicKeyClient publicKeyClient;
     private final EventsClient eventsClient;
     private final KickSignatureVerifier signatureVerifier;
@@ -79,6 +81,7 @@ public class KickClient {
         this.chatClient = new ChatClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.moderationClient = new ModerationClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.livestreamsClient = new LivestreamsClient(httpClient, objectMapper, configuration, this.authorizationClient);
+        this.kicksClient = new KicksClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.publicKeyClient = new PublicKeyClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.eventsClient = new EventsClient(httpClient, objectMapper, configuration, this.authorizationClient);
 
@@ -135,6 +138,10 @@ public class KickClient {
 
     public LivestreamsClient livestreams() {
         return livestreamsClient;
+    }
+
+    public KicksClient kicks() {
+        return kicksClient;
     }
 
     public PublicKeyClient publicKey() {

--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -29,6 +29,7 @@ public final class KickConfiguration {
     private final String channelsRewardsRedemptions;
     private final String channelsRewardsRedemptionsAccept;
     private final String channelsRewardsRedemptionsReject;
+    private final String kicksLeaderboard;
 
     private KickConfiguration(Builder builder) {
         this.tokenStore = builder.tokenStore;
@@ -55,6 +56,7 @@ public final class KickConfiguration {
         this.channelsRewardsRedemptions = builder.channelsRewardsRedemptions;
         this.channelsRewardsRedemptionsAccept = builder.channelsRewardsRedemptionsAccept;
         this.channelsRewardsRedemptionsReject = builder.channelsRewardsRedemptionsReject;
+        this.kicksLeaderboard = builder.kicksLeaderboard;
     }
 
     public static Builder builder() {
@@ -157,6 +159,10 @@ public final class KickConfiguration {
         return channelsRewardsRedemptionsReject;
     }
 
+    public String getKicksLeaderboard() {
+        return kicksLeaderboard;
+    }
+
     public static final class Builder {
         private RefreshTokenStore tokenStore;
         private String clientId;
@@ -182,6 +188,7 @@ public final class KickConfiguration {
         private String channelsRewardsRedemptions = "/channels/rewards/redemptions";
         private String channelsRewardsRedemptionsAccept = "/channels/rewards/redemptions/accept";
         private String channelsRewardsRedemptionsReject = "/channels/rewards/redemptions/reject";
+        private String kicksLeaderboard = "/kicks/leaderboard";
 
         public Builder tokenStore(RefreshTokenStore tokenStore) {
             this.tokenStore = tokenStore;
@@ -300,6 +307,11 @@ public final class KickConfiguration {
 
         public Builder channelsRewardsRedemptionsReject(String channelsRewardsRedemptionsReject) {
             this.channelsRewardsRedemptionsReject = channelsRewardsRedemptionsReject;
+            return this;
+        }
+
+        public Builder kicksLeaderboard(String kicksLeaderboard) {
+            this.kicksLeaderboard = kicksLeaderboard;
             return this;
         }
 

--- a/src/main/java/pl/teksusik/kick4j/kicks/KicksClient.java
+++ b/src/main/java/pl/teksusik/kick4j/kicks/KicksClient.java
@@ -1,0 +1,36 @@
+package pl.teksusik.kick4j.kicks;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import pl.teksusik.kick4j.KickConfiguration;
+import pl.teksusik.kick4j.api.ApiClient;
+import pl.teksusik.kick4j.authorization.AuthorizationClient;
+
+import java.net.http.HttpClient;
+import java.util.Map;
+
+public class KicksClient extends ApiClient {
+    public KicksClient(HttpClient httpClient, ObjectMapper mapper, KickConfiguration configuration, AuthorizationClient authorization) {
+        super(httpClient, mapper, configuration, authorization);
+    }
+
+    /**
+     * Gets the KICKs leaderboard for the authenticated broadcaster, using the API default
+     * of the top 10 entries.
+     */
+    public KicksLeaderboard getLeaderboard() {
+        return this.get(this.configuration.getKicksLeaderboard())
+                .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Gets the KICKs leaderboard for the authenticated broadcaster.
+     *
+     * @param top number of top entries to return (1-100)
+     */
+    public KicksLeaderboard getLeaderboard(int top) {
+        return this.get(this.configuration.getKicksLeaderboard())
+                .queryParams(Map.of("top", top))
+                .send(new TypeReference<>() {});
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/kicks/KicksLeaderboard.java
+++ b/src/main/java/pl/teksusik/kick4j/kicks/KicksLeaderboard.java
@@ -1,0 +1,33 @@
+package pl.teksusik.kick4j.kicks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class KicksLeaderboard {
+    private final List<KicksLeaderboardEntry> lifetime;
+    private final List<KicksLeaderboardEntry> month;
+    private final List<KicksLeaderboardEntry> week;
+
+    @JsonCreator
+    public KicksLeaderboard(@JsonProperty("lifetime") List<KicksLeaderboardEntry> lifetime,
+                            @JsonProperty("month") List<KicksLeaderboardEntry> month,
+                            @JsonProperty("week") List<KicksLeaderboardEntry> week) {
+        this.lifetime = lifetime;
+        this.month = month;
+        this.week = week;
+    }
+
+    public List<KicksLeaderboardEntry> getLifetime() {
+        return lifetime;
+    }
+
+    public List<KicksLeaderboardEntry> getMonth() {
+        return month;
+    }
+
+    public List<KicksLeaderboardEntry> getWeek() {
+        return week;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/kicks/KicksLeaderboardEntry.java
+++ b/src/main/java/pl/teksusik/kick4j/kicks/KicksLeaderboardEntry.java
@@ -1,0 +1,38 @@
+package pl.teksusik.kick4j.kicks;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KicksLeaderboardEntry {
+    private final Integer giftedAmount;
+    private final Integer rank;
+    private final Integer userId;
+    private final String username;
+
+    @JsonCreator
+    public KicksLeaderboardEntry(@JsonProperty("gifted_amount") Integer giftedAmount,
+                                 @JsonProperty("rank") Integer rank,
+                                 @JsonProperty("user_id") Integer userId,
+                                 @JsonProperty("username") String username) {
+        this.giftedAmount = giftedAmount;
+        this.rank = rank;
+        this.userId = userId;
+        this.username = username;
+    }
+
+    public Integer getGiftedAmount() {
+        return giftedAmount;
+    }
+
+    public Integer getRank() {
+        return rank;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}


### PR DESCRIPTION
Closes #15

Adds `KicksClient` (accessible via `kick.kicks()`) for the KICKs gifting leaderboard.

## Endpoint
- **GET `/kicks/leaderboard`** (scope `kicks:read`), query param `top` (1-100, default 10).
  - `getLeaderboard()` — uses the API default (top 10)
  - `getLeaderboard(int top)` — explicit count

## Models
- `KicksLeaderboard`: `lifetime`, `month`, `week` (lists of entries)
- `KicksLeaderboardEntry`: `rank`, `user_id`, `username`, `gifted_amount`

Registered in `KickClient`; path configurable in `KickConfiguration`. Scope `kicks:read` came from #13.

## Tests
None — this is a response DTO with no full documented payload to test against (per the agreed convention). `./gradlew clean build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)