### PR TITLE
Add chat message deletion endpoint

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -19,6 +19,7 @@ public final class KickConfiguration {
     private final String users;
     private final String channels;
     private final String chat;
+    private final String chatMessage;
     private final String moderation;
     private final String livestreams;
     private final String livestreamsStats;
@@ -46,6 +47,7 @@ public final class KickConfiguration {
         this.users = builder.users;
         this.channels = builder.channels;
         this.chat = builder.chat;
+        this.chatMessage = builder.chatMessage;
         this.moderation = builder.moderation;
         this.livestreams = builder.livestreams;
         this.livestreamsStats = builder.livestreamsStats;
@@ -119,6 +121,10 @@ public final class KickConfiguration {
         return chat;
     }
 
+    public String getChatMessage() {
+        return chatMessage;
+    }
+
     public String getModeration() {
         return moderation;
     }
@@ -178,6 +184,7 @@ public final class KickConfiguration {
         private String users = "/users";
         private String channels = "/channels";
         private String chat = "/chat";
+        private String chatMessage = "/chat/{message_id}";
         private String moderation = "/moderation/bans";
         private String livestreams = "/livestreams";
         private String livestreamsStats = "/livestreams/stats";
@@ -257,6 +264,11 @@ public final class KickConfiguration {
 
         public Builder chat(String chat) {
             this.chat = chat;
+            return this;
+        }
+
+        public Builder chatMessage(String chatMessage) {
+            this.chatMessage = chatMessage;
             return this;
         }
 

--- a/src/main/java/pl/teksusik/kick4j/chat/ChatClient.java
+++ b/src/main/java/pl/teksusik/kick4j/chat/ChatClient.java
@@ -7,6 +7,7 @@ import pl.teksusik.kick4j.api.ApiClient;
 import pl.teksusik.kick4j.authorization.AuthorizationClient;
 
 import java.net.http.HttpClient;
+import java.util.Map;
 
 public class ChatClient extends ApiClient {
     public ChatClient(HttpClient httpClient, ObjectMapper mapper, KickConfiguration configuration, AuthorizationClient authorization) {
@@ -16,6 +17,18 @@ public class ChatClient extends ApiClient {
     public PostChatMessageResponse postChatMessage(PostChatMessageRequest request) {
         return this.post(this.configuration.getChat())
                 .body(request)
+                .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Removes a message from a channel's chat.
+     * Requires the {@code moderation:chat_message:manage} scope.
+     *
+     * @param messageId the UUID of the message to delete
+     */
+    public void deleteChatMessage(String messageId) {
+        this.delete(this.configuration.getChatMessage())
+                .pathParams(Map.of("message_id", messageId))
                 .send(new TypeReference<>() {});
     }
 }


### PR DESCRIPTION
Closes #16

Adds `ChatClient.deleteChatMessage(String messageId)` for **DELETE `/chat/{message_id}`** (scope `moderation:chat_message:manage`, from #13). Path is configurable in `KickConfiguration`. Returns on 204 No Content.

## Tests
None — no response payload to deserialize (204). `./gradlew clean build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)