### PR TITLE
Add channel.reward.redemption.updated and kicks.gifted webhook events

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/events/type/ChannelRewardRedemptionUpdatedEvent.java
+++ b/src/main/java/pl/teksusik/kick4j/events/type/ChannelRewardRedemptionUpdatedEvent.java
@@ -1,0 +1,70 @@
+package pl.teksusik.kick4j.events.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import pl.teksusik.kick4j.rewards.RedemptionStatus;
+
+import java.time.Instant;
+
+public class ChannelRewardRedemptionUpdatedEvent extends KickEvent {
+    private final EventUser broadcaster;
+    private final String id;
+    private final Instant redeemedAt;
+    private final EventUser redeemer;
+    private final RedemptionReward reward;
+    private final RedemptionStatus status;
+    private final String userInput;
+
+    @JsonCreator
+    public ChannelRewardRedemptionUpdatedEvent(@JsonProperty("broadcaster") EventUser broadcaster,
+                                               @JsonProperty("id") String id,
+                                               @JsonProperty("redeemed_at") Instant redeemedAt,
+                                               @JsonProperty("redeemer") EventUser redeemer,
+                                               @JsonProperty("reward") RedemptionReward reward,
+                                               @JsonProperty("status") RedemptionStatus status,
+                                               @JsonProperty("user_input") String userInput) {
+        this.broadcaster = broadcaster;
+        this.id = id;
+        this.redeemedAt = redeemedAt;
+        this.redeemer = redeemer;
+        this.reward = reward;
+        this.status = status;
+        this.userInput = userInput;
+    }
+
+    public EventUser getBroadcaster() {
+        return broadcaster;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Instant getRedeemedAt() {
+        return redeemedAt;
+    }
+
+    public EventUser getRedeemer() {
+        return redeemer;
+    }
+
+    public RedemptionReward getReward() {
+        return reward;
+    }
+
+    public RedemptionStatus getStatus() {
+        return status;
+    }
+
+    public String getUserInput() {
+        return userInput;
+    }
+
+    public static String getEventType() {
+        return "channel.reward.redemption.updated";
+    }
+
+    public static String getEventVersion() {
+        return "1";
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/events/type/KicksGift.java
+++ b/src/main/java/pl/teksusik/kick4j/events/type/KicksGift.java
@@ -1,0 +1,52 @@
+package pl.teksusik.kick4j.events.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class KicksGift {
+    private final Integer amount;
+    private final String message;
+    private final String name;
+    private final Integer pinnedTimeSeconds;
+    private final String tier;
+    private final String type;
+
+    @JsonCreator
+    public KicksGift(@JsonProperty("amount") Integer amount,
+                     @JsonProperty("message") String message,
+                     @JsonProperty("name") String name,
+                     @JsonProperty("pinned_time_seconds") Integer pinnedTimeSeconds,
+                     @JsonProperty("tier") String tier,
+                     @JsonProperty("type") String type) {
+        this.amount = amount;
+        this.message = message;
+        this.name = name;
+        this.pinnedTimeSeconds = pinnedTimeSeconds;
+        this.tier = tier;
+        this.type = type;
+    }
+
+    public Integer getAmount() {
+        return amount;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Integer getPinnedTimeSeconds() {
+        return pinnedTimeSeconds;
+    }
+
+    public String getTier() {
+        return tier;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/events/type/KicksGiftedEvent.java
+++ b/src/main/java/pl/teksusik/kick4j/events/type/KicksGiftedEvent.java
@@ -1,0 +1,48 @@
+package pl.teksusik.kick4j.events.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+public class KicksGiftedEvent extends KickEvent {
+    private final EventUser broadcaster;
+    private final Instant createdAt;
+    private final KicksGift gift;
+    private final EventUser sender;
+
+    @JsonCreator
+    public KicksGiftedEvent(@JsonProperty("broadcaster") EventUser broadcaster,
+                            @JsonProperty("created_at") Instant createdAt,
+                            @JsonProperty("gift") KicksGift gift,
+                            @JsonProperty("sender") EventUser sender) {
+        this.broadcaster = broadcaster;
+        this.createdAt = createdAt;
+        this.gift = gift;
+        this.sender = sender;
+    }
+
+    public EventUser getBroadcaster() {
+        return broadcaster;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public KicksGift getGift() {
+        return gift;
+    }
+
+    public EventUser getSender() {
+        return sender;
+    }
+
+    public static String getEventType() {
+        return "kicks.gifted";
+    }
+
+    public static String getEventVersion() {
+        return "1";
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/events/type/RedemptionReward.java
+++ b/src/main/java/pl/teksusik/kick4j/events/type/RedemptionReward.java
@@ -1,0 +1,38 @@
+package pl.teksusik.kick4j.events.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RedemptionReward {
+    private final Integer cost;
+    private final String description;
+    private final String id;
+    private final String title;
+
+    @JsonCreator
+    public RedemptionReward(@JsonProperty("cost") Integer cost,
+                            @JsonProperty("description") String description,
+                            @JsonProperty("id") String id,
+                            @JsonProperty("title") String title) {
+        this.cost = cost;
+        this.description = description;
+        this.id = id;
+        this.title = title;
+    }
+
+    public Integer getCost() {
+        return cost;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/test/java/pl/teksusik/kick4j/events/ChannelRewardRedemptionUpdatedEventTest.java
+++ b/src/test/java/pl/teksusik/kick4j/events/ChannelRewardRedemptionUpdatedEventTest.java
@@ -1,0 +1,74 @@
+package pl.teksusik.kick4j.events;
+
+import org.junit.jupiter.api.Test;
+import pl.teksusik.kick4j.events.type.ChannelRewardRedemptionUpdatedEvent;
+import pl.teksusik.kick4j.events.type.EventUser;
+import pl.teksusik.kick4j.events.type.RedemptionReward;
+import pl.teksusik.kick4j.rewards.RedemptionStatus;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ChannelRewardRedemptionUpdatedEventTest extends KickEventDispatcherTest {
+    private static final String PAYLOAD = """
+            {
+              "id": "01KBHE78QE4HZY1617DK5FC7YD",
+              "user_input": "unban me",
+              "status": "rejected",
+              "redeemed_at": "2025-12-02T22:54:19.323Z",
+              "reward": {
+                "id": "01KBHE7RZNHB0SKDV1H86CD4F3",
+                "title": "Uban Request",
+                "cost": 1000,
+                "description": "Only good reasons pls"
+              },
+              "redeemer": {
+                "user_id": 123,
+                "username": "naughty-user",
+                "is_verified": false,
+                "profile_picture": "",
+                "channel_slug": "naughty_user"
+              },
+              "broadcaster": {
+                "user_id": 333,
+                "username": "gigachad",
+                "is_verified": true,
+                "profile_picture": "",
+                "channel_slug": "gigachad"
+              }
+            }""";
+
+    @Test
+    public void should_deserialize_channel_reward_redemption_updated_event() {
+        ChannelRewardRedemptionUpdatedEvent event = dispatchAndCapture(
+                ChannelRewardRedemptionUpdatedEvent.class,
+                "channel.reward.redemption.updated",
+                "1",
+                PAYLOAD
+        );
+
+        assertEquals("01KBHE78QE4HZY1617DK5FC7YD", event.getId());
+        assertEquals("unban me", event.getUserInput());
+        assertEquals(RedemptionStatus.REJECTED, event.getStatus());
+        assertEquals(Instant.parse("2025-12-02T22:54:19.323Z"), event.getRedeemedAt());
+
+        RedemptionReward reward = event.getReward();
+        assertNotNull(reward);
+        assertEquals("01KBHE7RZNHB0SKDV1H86CD4F3", reward.getId());
+        assertEquals("Uban Request", reward.getTitle());
+        assertEquals(1000, reward.getCost());
+        assertEquals("Only good reasons pls", reward.getDescription());
+
+        EventUser redeemer = event.getRedeemer();
+        assertNotNull(redeemer);
+        assertEquals(123, redeemer.getUserId());
+        assertEquals("naughty-user", redeemer.getUsername());
+
+        EventUser broadcaster = event.getBroadcaster();
+        assertNotNull(broadcaster);
+        assertEquals(333, broadcaster.getUserId());
+        assertEquals("gigachad", broadcaster.getUsername());
+    }
+}

--- a/src/test/java/pl/teksusik/kick4j/events/KicksGiftedEventTest.java
+++ b/src/test/java/pl/teksusik/kick4j/events/KicksGiftedEventTest.java
@@ -1,0 +1,71 @@
+package pl.teksusik.kick4j.events;
+
+import org.junit.jupiter.api.Test;
+import pl.teksusik.kick4j.events.type.EventUser;
+import pl.teksusik.kick4j.events.type.KicksGift;
+import pl.teksusik.kick4j.events.type.KicksGiftedEvent;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class KicksGiftedEventTest extends KickEventDispatcherTest {
+    private static final String PAYLOAD = """
+            {
+              "broadcaster": {
+                "user_id": 123456789,
+                "username": "broadcaster_name",
+                "is_verified": true,
+                "profile_picture": "https://example.com/broadcaster_avatar.jpg",
+                "channel_slug": "broadcaster_channel"
+              },
+              "sender": {
+                "user_id": 987654321,
+                "username": "gift_sender",
+                "is_verified": false,
+                "profile_picture": "https://example.com/sender_avatar.jpg",
+                "channel_slug": "gift_sender_channel"
+              },
+              "gift": {
+                "amount": 500,
+                "name": "Rage Quit",
+                "type": "LEVEL_UP",
+                "tier": "MID",
+                "message": "w",
+                "pinned_time_seconds": 600
+              },
+              "created_at": "2025-10-20T04:00:08.634Z"
+            }""";
+
+    @Test
+    public void should_deserialize_kicks_gifted_event() {
+        KicksGiftedEvent event = dispatchAndCapture(
+                KicksGiftedEvent.class,
+                "kicks.gifted",
+                "1",
+                PAYLOAD
+        );
+
+        assertEquals(Instant.parse("2025-10-20T04:00:08.634Z"), event.getCreatedAt());
+
+        EventUser broadcaster = event.getBroadcaster();
+        assertNotNull(broadcaster);
+        assertEquals(123456789, broadcaster.getUserId());
+        assertEquals("broadcaster_name", broadcaster.getUsername());
+
+        EventUser sender = event.getSender();
+        assertNotNull(sender);
+        assertEquals(987654321, sender.getUserId());
+        assertEquals("gift_sender", sender.getUsername());
+
+        KicksGift gift = event.getGift();
+        assertNotNull(gift);
+        assertEquals(500, gift.getAmount());
+        assertEquals("Rage Quit", gift.getName());
+        assertEquals("LEVEL_UP", gift.getType());
+        assertEquals("MID", gift.getTier());
+        assertEquals("w", gift.getMessage());
+        assertEquals(600, gift.getPinnedTimeSeconds());
+    }
+}


### PR DESCRIPTION
Closes #17

Adds the two webhook event types the library was missing.

## New events
- **`channel.reward.redemption.updated`** (v1) → `ChannelRewardRedemptionUpdatedEvent`
  Fields: `id`, `user_input`, `status` (reuses `RedemptionStatus`), `redeemed_at`, `reward` (`RedemptionReward`: id/title/cost/description), `redeemer`, `broadcaster`.
- **`kicks.gifted`** (v1) → `KicksGiftedEvent`
  Fields: `broadcaster`, `sender`, `gift` (`KicksGift`: amount/name/type/tier/message/pinned_time_seconds), `created_at`.

## Notes
- The `redeemer`/`broadcaster`/`sender` objects use the **reduced** user shape (no `is_anonymous`/`identity`); these reuse `EventUser`, where the absent fields deserialize as `null`.
- Events self-register through their static `getEventType`/`getEventVersion`, so **no `KickEventDispatcher` change** is required.

## Tests
`ChannelRewardRedemptionUpdatedEventTest` and `KicksGiftedEventTest` use the **exact payloads from the Kick docs** (events have full documented payloads), mirroring the existing event tests. `./gradlew clean build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)