### PR TITLE
Migrate Categories to the paginated V2 endpoint

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -13,6 +13,7 @@ public final class KickConfiguration {
     private final String authorizationEndpoint;
     private final String tokenEndpoint;
     private final String baseUrl;
+    private final String baseUrlV2;
     private final String categories;
     private final String categoriesId;
     private final String tokenIntrospect;
@@ -41,6 +42,7 @@ public final class KickConfiguration {
         this.authorizationEndpoint = builder.authorizationEndpoint;
         this.tokenEndpoint = builder.tokenEndpoint;
         this.baseUrl = builder.baseUrl;
+        this.baseUrlV2 = builder.baseUrlV2;
         this.categories = builder.categories;
         this.categoriesId = builder.categoriesId;
         this.tokenIntrospect = builder.tokenIntrospect;
@@ -95,6 +97,10 @@ public final class KickConfiguration {
 
     public String getBaseUrl() {
         return baseUrl;
+    }
+
+    public String getBaseUrlV2() {
+        return baseUrlV2;
     }
 
     public String getCategories() {
@@ -178,6 +184,7 @@ public final class KickConfiguration {
         private String authorizationEndpoint = "/oauth/authorize";
         private String tokenEndpoint = "/oauth/token";
         private String baseUrl = "https://api.kick.com/public/v1";
+        private String baseUrlV2 = "https://api.kick.com/public/v2";
         private String categories = "/categories";
         private String categoriesId = "/categories/{id}";
         private String tokenIntrospect = "/token/introspect";
@@ -234,6 +241,11 @@ public final class KickConfiguration {
 
         public Builder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
+            return this;
+        }
+
+        public Builder baseUrlV2(String baseUrlV2) {
+            this.baseUrlV2 = baseUrlV2;
             return this;
         }
 

--- a/src/main/java/pl/teksusik/kick4j/api/ApiClient.java
+++ b/src/main/java/pl/teksusik/kick4j/api/ApiClient.java
@@ -1,6 +1,7 @@
 package pl.teksusik.kick4j.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import pl.teksusik.kick4j.KickConfiguration;
 import pl.teksusik.kick4j.authorization.AuthorizationClient;
@@ -48,6 +49,7 @@ public abstract class ApiClient {
     public class RequestBuilder {
         private final String method;
         private String path;
+        private String baseUrl;
         private Map<String, Object> queryParams;
         private Object bodyObject;
         private Class<?> bodyClass;
@@ -55,6 +57,15 @@ public abstract class ApiClient {
         public RequestBuilder(String method, String path) {
             this.method = method;
             this.path = path;
+            this.baseUrl = configuration.getBaseUrl();
+        }
+
+        /**
+         * Overrides the base URL for this request (e.g. to target the {@code /public/v2} API).
+         */
+        public RequestBuilder baseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+            return this;
         }
 
         public RequestBuilder queryParams(Map<String, Object> queryParams) {
@@ -93,34 +104,70 @@ public abstract class ApiClient {
             return this;
         }
 
+        private HttpResponse<String> execute() throws IOException, InterruptedException {
+            String url = buildUrl(this.baseUrl + this.path, this.queryParams);
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Authorization", "Bearer " + authorization.getAccessToken())
+                    .header("Accept", "application/json");
+
+            if ("GET".equalsIgnoreCase(method)) {
+                requestBuilder.GET();
+            } else {
+                String jsonBody = this.bodyObject == null ? "" : mapper.writeValueAsString(this.bodyObject);
+                requestBuilder.header("Content-Type", "application/json");
+                requestBuilder.method(this.method, HttpRequest.BodyPublishers.ofString(jsonBody));
+            }
+
+            return httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+        }
+
         public <T> T send(TypeReference<ApiResponse<T>> typeRef) {
             try {
-                String url = buildUrl(configuration.getBaseUrl() + this.path, this.queryParams);
-                HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                        .uri(URI.create(url))
-                        .header("Authorization", "Bearer " + authorization.getAccessToken())
-                        .header("Accept", "application/json");
-
-                if ("GET".equalsIgnoreCase(method)) {
-                    requestBuilder.GET();
-                } else {
-                    String jsonBody = this.bodyObject == null ? "" : mapper.writeValueAsString(this.bodyObject);
-                    requestBuilder.header("Content-Type", "application/json");
-                    requestBuilder.method(this.method, HttpRequest.BodyPublishers.ofString(jsonBody));
-                }
-
-                HttpResponse<String> response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+                HttpResponse<String> response = execute();
                 String body = response.body();
                 if (body == null || body.isEmpty()) {
                     return null;
                 }
 
-                ApiResponse<T> apiResponse = mapper.readValue(response.body(), typeRef);
+                ApiResponse<T> apiResponse = mapper.readValue(body, typeRef);
                 if (!apiResponse.isSuccess() && response.statusCode() >= 400) {
                     throw new ApiException(response.statusCode(), apiResponse.getMessage());
                 }
 
                 return apiResponse.getData();
+            } catch (IOException | InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Failed to send API request", exception);
+            }
+        }
+
+        /**
+         * Sends the request and deserializes the whole response body into {@code typeRef}
+         * (rather than unwrapping only the {@code data} field). Used for paginated
+         * responses that also carry a {@code pagination} object.
+         */
+        public <T> T sendRaw(TypeReference<T> typeRef) {
+            try {
+                HttpResponse<String> response = execute();
+                String body = response.body();
+                if (body == null || body.isEmpty()) {
+                    return null;
+                }
+
+                if (response.statusCode() >= 400) {
+                    String message = null;
+                    try {
+                        JsonNode node = mapper.readTree(body);
+                        if (node.has("message")) {
+                            message = node.get("message").asText(null);
+                        }
+                    } catch (IOException ignored) {
+                    }
+                    throw new ApiException(response.statusCode(), message);
+                }
+
+                return mapper.readValue(body, typeRef);
             } catch (IOException | InterruptedException exception) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException("Failed to send API request", exception);

--- a/src/main/java/pl/teksusik/kick4j/api/PaginatedResponse.java
+++ b/src/main/java/pl/teksusik/kick4j/api/PaginatedResponse.java
@@ -1,0 +1,39 @@
+package pl.teksusik.kick4j.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * A cursor-paginated API response carrying both the {@code data} page and the
+ * {@code pagination} cursor. Use {@link Pagination#getNextCursor()} to fetch the next page.
+ *
+ * @param <T> the element type of the {@code data} array
+ */
+public class PaginatedResponse<T> {
+    private final List<T> data;
+    private final String message;
+    private final Pagination pagination;
+
+    @JsonCreator
+    public PaginatedResponse(@JsonProperty("data") List<T> data,
+                             @JsonProperty("message") String message,
+                             @JsonProperty("pagination") Pagination pagination) {
+        this.data = data;
+        this.message = message;
+        this.pagination = pagination;
+    }
+
+    public List<T> getData() {
+        return data;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Pagination getPagination() {
+        return pagination;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/api/Pagination.java
+++ b/src/main/java/pl/teksusik/kick4j/api/Pagination.java
@@ -1,0 +1,17 @@
+package pl.teksusik.kick4j.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Pagination {
+    private final String nextCursor;
+
+    @JsonCreator
+    public Pagination(@JsonProperty("next_cursor") String nextCursor) {
+        this.nextCursor = nextCursor;
+    }
+
+    public String getNextCursor() {
+        return nextCursor;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/categories/CategoriesClient.java
+++ b/src/main/java/pl/teksusik/kick4j/categories/CategoriesClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import pl.teksusik.kick4j.KickConfiguration;
 import pl.teksusik.kick4j.api.ApiClient;
+import pl.teksusik.kick4j.api.PaginatedResponse;
 import pl.teksusik.kick4j.authorization.AuthorizationClient;
 
 import java.net.http.HttpClient;
@@ -15,10 +16,21 @@ public class CategoriesClient extends ApiClient {
         super(httpClient, mapper, configuration, authorization);
     }
 
+    /**
+     * @deprecated The V1 categories endpoint is deprecated by Kick and will be removed.
+     * Use {@link #getCategoriesV2(GetCategoriesV2Request)} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public List<Category> getCategories(String query) {
         return this.getCategories(query, 1);
     }
 
+    /**
+     * @deprecated The V1 categories endpoint is deprecated by Kick and will be removed.
+     * Use {@link #getCategoriesV2(GetCategoriesV2Request)} instead.
+     */
+    @Deprecated
     public List<Category> getCategories(String query, int page) {
         return this.get(this.configuration.getCategories())
                 .queryParams(Map.of("q", query,
@@ -26,9 +38,33 @@ public class CategoriesClient extends ApiClient {
                 .send(new TypeReference<>() {});
     }
 
+    /**
+     * @deprecated The V1 categories endpoint is deprecated by Kick and will be removed.
+     * Use {@link #getCategoriesV2(GetCategoriesV2Request)} instead.
+     */
+    @Deprecated
     public Category getCategory(int categoryId) {
         return this.get(this.configuration.getCategoriesId())
                 .pathParams(Map.of("id", categoryId))
                 .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Lists categories via the paginated V2 endpoint, with default filters
+     * (first page, API default limit).
+     */
+    public PaginatedResponse<CategoryWithTags> getCategoriesV2() {
+        return this.getCategoriesV2(GetCategoriesV2Request.builder().build());
+    }
+
+    /**
+     * Lists categories via the paginated V2 endpoint using the provided filters.
+     * Use {@link PaginatedResponse#getPagination()} to page through results with a cursor.
+     */
+    public PaginatedResponse<CategoryWithTags> getCategoriesV2(GetCategoriesV2Request request) {
+        return this.get(this.configuration.getCategories())
+                .baseUrl(this.configuration.getBaseUrlV2())
+                .queryParams(request.toQueryParams())
+                .sendRaw(new TypeReference<>() {});
     }
 }

--- a/src/main/java/pl/teksusik/kick4j/categories/CategoryWithTags.java
+++ b/src/main/java/pl/teksusik/kick4j/categories/CategoryWithTags.java
@@ -1,0 +1,40 @@
+package pl.teksusik.kick4j.categories;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class CategoryWithTags {
+    private final Integer id;
+    private final String name;
+    private final List<String> tags;
+    private final String thumbnail;
+
+    @JsonCreator
+    public CategoryWithTags(@JsonProperty("id") Integer id,
+                            @JsonProperty("name") String name,
+                            @JsonProperty("tags") List<String> tags,
+                            @JsonProperty("thumbnail") String thumbnail) {
+        this.id = id;
+        this.name = name;
+        this.tags = tags;
+        this.thumbnail = thumbnail;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public String getThumbnail() {
+        return thumbnail;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/categories/GetCategoriesV2Request.java
+++ b/src/main/java/pl/teksusik/kick4j/categories/GetCategoriesV2Request.java
@@ -1,0 +1,112 @@
+package pl.teksusik.kick4j.categories;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Filters for the paginated V2 categories endpoint.
+ * <p>
+ * The {@code names}, {@code tags} and {@code ids} arrays are sent as comma-separated
+ * (CSV) query parameters, matching the API's {@code collectionFormat: csv}.
+ */
+public class GetCategoriesV2Request {
+    private final String cursor;
+    private final Integer limit;
+    private final List<String> names;
+    private final List<String> tags;
+    private final List<Integer> ids;
+
+    public GetCategoriesV2Request(String cursor, Integer limit, List<String> names, List<String> tags, List<Integer> ids) {
+        this.cursor = cursor;
+        this.limit = limit;
+        this.names = names;
+        this.tags = tags;
+        this.ids = ids;
+    }
+
+    public String getCursor() {
+        return cursor;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public List<Integer> getIds() {
+        return ids;
+    }
+
+    /**
+     * Builds the query parameter map, joining array filters into CSV values.
+     */
+    public Map<String, Object> toQueryParams() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        if (this.cursor != null) {
+            params.put("cursor", this.cursor);
+        }
+        if (this.limit != null) {
+            params.put("limit", this.limit);
+        }
+        if (this.names != null && !this.names.isEmpty()) {
+            params.put("name", String.join(",", this.names));
+        }
+        if (this.tags != null && !this.tags.isEmpty()) {
+            params.put("tag", String.join(",", this.tags));
+        }
+        if (this.ids != null && !this.ids.isEmpty()) {
+            params.put("id", this.ids.stream().map(String::valueOf).collect(Collectors.joining(",")));
+        }
+        return params;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String cursor;
+        private Integer limit;
+        private List<String> names;
+        private List<String> tags;
+        private List<Integer> ids;
+
+        public Builder cursor(String cursor) {
+            this.cursor = cursor;
+            return this;
+        }
+
+        public Builder limit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public Builder names(List<String> names) {
+            this.names = names;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Builder ids(List<Integer> ids) {
+            this.ids = ids;
+            return this;
+        }
+
+        public GetCategoriesV2Request build() {
+            return new GetCategoriesV2Request(cursor, limit, names, tags, ids);
+        }
+    }
+}

--- a/src/test/java/pl/teksusik/kick4j/categories/GetCategoriesV2RequestTest.java
+++ b/src/test/java/pl/teksusik/kick4j/categories/GetCategoriesV2RequestTest.java
@@ -1,0 +1,48 @@
+package pl.teksusik.kick4j.categories;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Verifies the CSV query-parameter building of our own V2 request DTO.
+ */
+public class GetCategoriesV2RequestTest {
+
+    @Test
+    public void joins_arrays_as_csv_and_maps_param_names() {
+        Map<String, Object> params = GetCategoriesV2Request.builder()
+                .cursor("abcd")
+                .limit(50)
+                .names(List.of("Rust", "Just Chatting"))
+                .tags(List.of("FPS", "Shooter"))
+                .ids(List.of(1, 2, 3))
+                .build()
+                .toQueryParams();
+
+        assertEquals("abcd", params.get("cursor"));
+        assertEquals(50, params.get("limit"));
+        assertEquals("Rust,Just Chatting", params.get("name"));
+        assertEquals("FPS,Shooter", params.get("tag"));
+        assertEquals("1,2,3", params.get("id"));
+    }
+
+    @Test
+    public void omits_null_and_empty_filters() {
+        Map<String, Object> params = GetCategoriesV2Request.builder()
+                .limit(10)
+                .names(List.of())
+                .build()
+                .toQueryParams();
+
+        assertEquals(10, params.get("limit"));
+        assertFalse(params.containsKey("name"));
+        assertFalse(params.containsKey("tag"));
+        assertFalse(params.containsKey("id"));
+        assertFalse(params.containsKey("cursor"));
+    }
+}


### PR DESCRIPTION
Closes #18

Adds the **GET `/public/v2/categories`** endpoint (cursor pagination + tags), and builds the reusable pagination infrastructure that #19 will also use. The deprecated V1 methods keep working.

## Infrastructure (reused by #19)
- **`ApiClient`**: a per-request `baseUrl(...)` override (to target `/public/v2`) and a new `sendRaw(TypeReference<T>)` that deserializes the **whole** response body (so `pagination` survives), rather than unwrapping only `data`.
- **`api.PaginatedResponse<T>`** (`data` + `message` + `pagination`) and **`api.Pagination`** (`next_cursor`).
- **`KickConfiguration.baseUrlV2`** — configurable, defaults to `https://api.kick.com/public/v2`.

## Categories
- **`CategoryWithTags`** model (`id`, `name`, `tags`, `thumbnail`).
- **`GetCategoriesV2Request`** — `cursor`, `limit`, and `names`/`tags`/`ids` sent as **CSV** (`collectionFormat: csv`) via `toQueryParams()`.
- **`CategoriesClient.getCategoriesV2([request])`** returning `PaginatedResponse<CategoryWithTags>`.
- V1 `getCategories`/`getCategory` annotated `@Deprecated` (kept for backward compatibility).

## Tests
`GetCategoriesV2RequestTest` verifies our own CSV param building (join + name mapping + omission) — not a fabricated API payload. `./gradlew clean build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)