### PR TITLE
Migrate Livestreams to V2 and add users/livestreams endpoint

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -24,6 +24,7 @@ public final class KickConfiguration {
     private final String moderation;
     private final String livestreams;
     private final String livestreamsStats;
+    private final String usersLivestreams;
     private final String publicKey;
     private final String events;
     private final String channelsRewards;
@@ -53,6 +54,7 @@ public final class KickConfiguration {
         this.moderation = builder.moderation;
         this.livestreams = builder.livestreams;
         this.livestreamsStats = builder.livestreamsStats;
+        this.usersLivestreams = builder.usersLivestreams;
         this.publicKey = builder.publicKey;
         this.events = builder.events;
         this.channelsRewards = builder.channelsRewards;
@@ -143,6 +145,10 @@ public final class KickConfiguration {
         return livestreamsStats;
     }
 
+    public String getUsersLivestreams() {
+        return usersLivestreams;
+    }
+
     public String getPublicKey() {
         return publicKey;
     }
@@ -195,6 +201,7 @@ public final class KickConfiguration {
         private String moderation = "/moderation/bans";
         private String livestreams = "/livestreams";
         private String livestreamsStats = "/livestreams/stats";
+        private String usersLivestreams = "/users/livestreams";
         private String publicKey = "/public-key";
         private String events = "/events/subscriptions";
         private String channelsRewards = "/channels/rewards";
@@ -296,6 +303,11 @@ public final class KickConfiguration {
 
         public Builder livestreamsStats(String livestreamsStats) {
             this.livestreamsStats = livestreamsStats;
+            return this;
+        }
+
+        public Builder usersLivestreams(String usersLivestreams) {
+            this.usersLivestreams = usersLivestreams;
             return this;
         }
 

--- a/src/main/java/pl/teksusik/kick4j/livestreams/GetLivestreamsV2Request.java
+++ b/src/main/java/pl/teksusik/kick4j/livestreams/GetLivestreamsV2Request.java
@@ -1,0 +1,80 @@
+package pl.teksusik.kick4j.livestreams;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Filters for the paginated V2 livestreams endpoint. The {@code categoryId} and
+ * {@code languageCode} arrays are sent as repeated (multi) query parameters.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetLivestreamsV2Request {
+    @JsonProperty("category_id")
+    private final List<Integer> categoryId;
+    @JsonProperty("language_code")
+    private final List<String> languageCode;
+    @JsonProperty("limit")
+    private final Integer limit;
+    @JsonProperty("cursor")
+    private final String cursor;
+
+    public GetLivestreamsV2Request(List<Integer> categoryId, List<String> languageCode, Integer limit, String cursor) {
+        this.categoryId = categoryId;
+        this.languageCode = languageCode;
+        this.limit = limit;
+        this.cursor = cursor;
+    }
+
+    public List<Integer> getCategoryId() {
+        return categoryId;
+    }
+
+    public List<String> getLanguageCode() {
+        return languageCode;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public String getCursor() {
+        return cursor;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private List<Integer> categoryId;
+        private List<String> languageCode;
+        private Integer limit;
+        private String cursor;
+
+        public Builder categoryId(List<Integer> categoryId) {
+            this.categoryId = categoryId;
+            return this;
+        }
+
+        public Builder languageCode(List<String> languageCode) {
+            this.languageCode = languageCode;
+            return this;
+        }
+
+        public Builder limit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public Builder cursor(String cursor) {
+            this.cursor = cursor;
+            return this;
+        }
+
+        public GetLivestreamsV2Request build() {
+            return new GetLivestreamsV2Request(categoryId, languageCode, limit, cursor);
+        }
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/livestreams/LivestreamChannel.java
+++ b/src/main/java/pl/teksusik/kick4j/livestreams/LivestreamChannel.java
@@ -1,0 +1,17 @@
+package pl.teksusik.kick4j.livestreams;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LivestreamChannel {
+    private final String slug;
+
+    @JsonCreator
+    public LivestreamChannel(@JsonProperty("slug") String slug) {
+        this.slug = slug;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/livestreams/LivestreamUser.java
+++ b/src/main/java/pl/teksusik/kick4j/livestreams/LivestreamUser.java
@@ -1,0 +1,31 @@
+package pl.teksusik.kick4j.livestreams;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LivestreamUser {
+    private final Integer id;
+    private final String profilePicture;
+    private final String username;
+
+    @JsonCreator
+    public LivestreamUser(@JsonProperty("id") Integer id,
+                          @JsonProperty("profile_picture") String profilePicture,
+                          @JsonProperty("username") String username) {
+        this.id = id;
+        this.profilePicture = profilePicture;
+        this.username = username;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getProfilePicture() {
+        return profilePicture;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/livestreams/LivestreamV2.java
+++ b/src/main/java/pl/teksusik/kick4j/livestreams/LivestreamV2.java
@@ -1,0 +1,90 @@
+package pl.teksusik.kick4j.livestreams;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import pl.teksusik.kick4j.categories.Category;
+
+import java.util.List;
+
+public class LivestreamV2 {
+    private final LivestreamUser broadcasterUser;
+    private final Category category;
+    private final LivestreamChannel channel;
+    private final Boolean hasMatureContent;
+    private final String id;
+    private final String languageCode;
+    private final String startedAt;
+    private final List<String> tags;
+    private final String thumbnail;
+    private final String title;
+    private final Integer viewerCount;
+
+    @JsonCreator
+    public LivestreamV2(@JsonProperty("broadcaster_user") LivestreamUser broadcasterUser,
+                        @JsonProperty("category") Category category,
+                        @JsonProperty("channel") LivestreamChannel channel,
+                        @JsonProperty("has_mature_content") Boolean hasMatureContent,
+                        @JsonProperty("id") String id,
+                        @JsonProperty("language_code") String languageCode,
+                        @JsonProperty("started_at") String startedAt,
+                        @JsonProperty("tags") List<String> tags,
+                        @JsonProperty("thumbnail") String thumbnail,
+                        @JsonProperty("title") String title,
+                        @JsonProperty("viewer_count") Integer viewerCount) {
+        this.broadcasterUser = broadcasterUser;
+        this.category = category;
+        this.channel = channel;
+        this.hasMatureContent = hasMatureContent;
+        this.id = id;
+        this.languageCode = languageCode;
+        this.startedAt = startedAt;
+        this.tags = tags;
+        this.thumbnail = thumbnail;
+        this.title = title;
+        this.viewerCount = viewerCount;
+    }
+
+    public LivestreamUser getBroadcasterUser() {
+        return broadcasterUser;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public LivestreamChannel getChannel() {
+        return channel;
+    }
+
+    public Boolean getHasMatureContent() {
+        return hasMatureContent;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getLanguageCode() {
+        return languageCode;
+    }
+
+    public String getStartedAt() {
+        return startedAt;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public String getThumbnail() {
+        return thumbnail;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Integer getViewerCount() {
+        return viewerCount;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/livestreams/LivestreamsClient.java
+++ b/src/main/java/pl/teksusik/kick4j/livestreams/LivestreamsClient.java
@@ -4,16 +4,24 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import pl.teksusik.kick4j.KickConfiguration;
 import pl.teksusik.kick4j.api.ApiClient;
+import pl.teksusik.kick4j.api.PaginatedResponse;
 import pl.teksusik.kick4j.authorization.AuthorizationClient;
 
 import java.net.http.HttpClient;
 import java.util.List;
+import java.util.Map;
 
 public class LivestreamsClient extends ApiClient {
     public LivestreamsClient(HttpClient httpClient, ObjectMapper mapper, KickConfiguration configuration, AuthorizationClient authorization) {
         super(httpClient, mapper, configuration, authorization);
     }
 
+    /**
+     * @deprecated The V1 livestreams endpoint is deprecated by Kick. Use
+     * {@link #getLivestreamsV2(GetLivestreamsV2Request)} or {@link #getUserLivestreams(List)} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public Livestream getLivestream(Integer broadcasterUserId) {
         return this.getLivestreams(GetLivestreamsRequest.builder()
                 .broadcasterUserId(broadcasterUserId).build())
@@ -22,9 +30,47 @@ public class LivestreamsClient extends ApiClient {
                 .orElse(null);
     }
 
+    /**
+     * @deprecated The V1 livestreams endpoint is deprecated by Kick. Use
+     * {@link #getLivestreamsV2(GetLivestreamsV2Request)} or {@link #getUserLivestreams(List)} instead.
+     */
+    @Deprecated
     public List<Livestream> getLivestreams(GetLivestreamsRequest request) {
         return this.get(this.configuration.getLivestreams())
                 .queryParams(request)
+                .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Lists active livestreams via the paginated V2 endpoint, with default filters.
+     */
+    public PaginatedResponse<LivestreamV2> getLivestreamsV2() {
+        return this.getLivestreamsV2(GetLivestreamsV2Request.builder().build());
+    }
+
+    /**
+     * Lists active livestreams via the paginated V2 endpoint using the provided filters.
+     * Results are sorted oldest to newest. Use {@link PaginatedResponse#getPagination()} to page.
+     */
+    public PaginatedResponse<LivestreamV2> getLivestreamsV2(GetLivestreamsV2Request request) {
+        return this.get(this.configuration.getLivestreams())
+                .baseUrl(this.configuration.getBaseUrlV2())
+                .queryParams(request)
+                .sendRaw(new TypeReference<>() {});
+    }
+
+    /**
+     * Gets the active livestreams for the given broadcaster user IDs (max 100).
+     */
+    public List<LivestreamV2> getUserLivestreams(List<Integer> userIds) {
+        return this.get(this.configuration.getUsersLivestreams())
+                .queryParams(Map.of("user_id", userIds))
+                .send(new TypeReference<>() {});
+    }
+
+    public List<LivestreamV2> getUserLivestreams(int... userIds) {
+        return this.get(this.configuration.getUsersLivestreams())
+                .queryParams(Map.of("user_id", userIds))
                 .send(new TypeReference<>() {});
     }
 


### PR DESCRIPTION
Closes #19

Adds the paginated **GET `/public/v2/livestreams`** and **GET `/public/v1/users/livestreams`** endpoints, reusing the pagination infrastructure from #18. Deprecated V1 methods keep working.

## Models
- **`LivestreamV2`** — distinct from the V1 `Livestream`: `id` (UUID), `title`, `thumbnail`, `started_at`, `viewer_count`, `has_mature_content`, `language_code`, `tags`, plus nested `broadcaster_user` (`LivestreamUser`), `channel` (`LivestreamChannel`), and `category` (reuses the existing `Category`).
- **`GetLivestreamsV2Request`** — `category_id`, `language_code` (repeated/multi params), `limit`, `cursor`.

## Client
- `getLivestreamsV2([request])` → `PaginatedResponse<LivestreamV2>` (sorted oldest→newest; page via the cursor).
- `getUserLivestreams(userIds)` / varargs → `List<LivestreamV2>` (max 100 IDs, required).
- V1 `getLivestreams`/`getLivestream` annotated `@Deprecated`; `getLivestreamsStats()` unchanged.

The existing `Livestream` V1 model is untouched — `LivestreamV2` is a separate type.

## Tests
None added — these are response DTOs with no full documented payloads (per the agreed convention); the V2 request uses the existing, already-exercised query-param path. `./gradlew clean build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)