### PR TITLE
Add OAuth token revoke and relocate token introspect to /oauth

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -12,6 +12,8 @@ public final class KickConfiguration {
     private final String oAuthHost;
     private final String authorizationEndpoint;
     private final String tokenEndpoint;
+    private final String revokeEndpoint;
+    private final String introspectEndpoint;
     private final String baseUrl;
     private final String baseUrlV2;
     private final String categories;
@@ -42,6 +44,8 @@ public final class KickConfiguration {
         this.oAuthHost = builder.oAuthHost;
         this.authorizationEndpoint = builder.authorizationEndpoint;
         this.tokenEndpoint = builder.tokenEndpoint;
+        this.revokeEndpoint = builder.revokeEndpoint;
+        this.introspectEndpoint = builder.introspectEndpoint;
         this.baseUrl = builder.baseUrl;
         this.baseUrlV2 = builder.baseUrlV2;
         this.categories = builder.categories;
@@ -95,6 +99,14 @@ public final class KickConfiguration {
 
     public String getTokenEndpoint() {
         return tokenEndpoint;
+    }
+
+    public String getRevokeEndpoint() {
+        return revokeEndpoint;
+    }
+
+    public String getIntrospectEndpoint() {
+        return introspectEndpoint;
     }
 
     public String getBaseUrl() {
@@ -189,6 +201,8 @@ public final class KickConfiguration {
         private String oAuthHost = "https://id.kick.com";
         private String authorizationEndpoint = "/oauth/authorize";
         private String tokenEndpoint = "/oauth/token";
+        private String revokeEndpoint = "/oauth/revoke";
+        private String introspectEndpoint = "/oauth/token/introspect";
         private String baseUrl = "https://api.kick.com/public/v1";
         private String baseUrlV2 = "https://api.kick.com/public/v2";
         private String categories = "/categories";
@@ -243,6 +257,16 @@ public final class KickConfiguration {
 
         public Builder tokenEndpoint(String tokenEndpoint) {
             this.tokenEndpoint = tokenEndpoint;
+            return this;
+        }
+
+        public Builder revokeEndpoint(String revokeEndpoint) {
+            this.revokeEndpoint = revokeEndpoint;
+            return this;
+        }
+
+        public Builder introspectEndpoint(String introspectEndpoint) {
+            this.introspectEndpoint = introspectEndpoint;
             return this;
         }
 

--- a/src/main/java/pl/teksusik/kick4j/authorization/AuthorizationClient.java
+++ b/src/main/java/pl/teksusik/kick4j/authorization/AuthorizationClient.java
@@ -1,7 +1,9 @@
 package pl.teksusik.kick4j.authorization;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import pl.teksusik.kick4j.KickConfiguration;
+import pl.teksusik.kick4j.users.TokenIntrospect;
 
 import java.io.IOException;
 import java.net.URI;
@@ -142,6 +144,87 @@ public class AuthorizationClient {
         OAuthTokenResponse newToken = this.postOAuthTokenRequest(body);
         this.refreshToken.notifyRefreshTokenRoll(newToken.getRefreshToken());
         return newToken;
+    }
+
+    /**
+     * Revokes access for the given token.
+     *
+     * @param token the access or refresh token to revoke
+     */
+    public void revokeToken(String token) {
+        this.revokeToken(token, null);
+    }
+
+    /**
+     * Revokes access for the given token.
+     *
+     * @param token the access or refresh token to revoke
+     * @param hint  optional hint about the token type to speed up the lookup
+     */
+    public void revokeToken(String token, TokenTypeHint hint) {
+        StringJoiner query = new StringJoiner("&");
+        query.add("token=" + encodeUrl(token));
+        if (hint != null) {
+            query.add("token_hint_type=" + encodeUrl(hint.getValue()));
+        }
+
+        String url = this.configuration.getOAuthHost() + this.configuration.getRevokeEndpoint() + "?" + query;
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.noBody())
+                    .build();
+
+            HttpResponse<String> response = this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new OAuthTokenException(response.statusCode(), response.body());
+            }
+        } catch (IOException | InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Failed to revoke token", exception);
+        }
+    }
+
+    /**
+     * Introspects the current managed access token via the OAuth introspection endpoint.
+     */
+    public TokenIntrospect introspectToken() {
+        return this.introspectToken(this.getAccessToken());
+    }
+
+    /**
+     * Introspects the given access token via the OAuth introspection endpoint
+     * ({@code POST /oauth/token/introspect} on the OAuth host).
+     *
+     * @param accessToken the access token to introspect
+     */
+    public TokenIntrospect introspectToken(String accessToken) {
+        String url = this.configuration.getOAuthHost() + this.configuration.getIntrospectEndpoint();
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("Accept", "application/json")
+                    .POST(HttpRequest.BodyPublishers.noBody())
+                    .build();
+
+            HttpResponse<String> response = this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new OAuthTokenException(response.statusCode(), response.body());
+            }
+
+            JsonNode root = this.mapper.readTree(response.body());
+            JsonNode data = root.get("data");
+            if (data == null || data.isNull()) {
+                return null;
+            }
+
+            return this.mapper.treeToValue(data, TokenIntrospect.class);
+        } catch (IOException | InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Failed to introspect token", exception);
+        }
     }
 
     /**

--- a/src/main/java/pl/teksusik/kick4j/authorization/TokenTypeHint.java
+++ b/src/main/java/pl/teksusik/kick4j/authorization/TokenTypeHint.java
@@ -1,0 +1,16 @@
+package pl.teksusik.kick4j.authorization;
+
+public enum TokenTypeHint {
+    ACCESS_TOKEN("access_token"),
+    REFRESH_TOKEN("refresh_token");
+
+    private final String value;
+
+    TokenTypeHint(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/users/UsersClient.java
+++ b/src/main/java/pl/teksusik/kick4j/users/UsersClient.java
@@ -15,6 +15,12 @@ public class UsersClient extends ApiClient {
         super(httpClient, mapper, configuration, authorization);
     }
 
+    /**
+     * @deprecated The {@code /public/v1/token/introspect} endpoint is deprecated by Kick.
+     * Use {@link pl.teksusik.kick4j.authorization.AuthorizationClient#introspectToken()},
+     * which targets the new {@code /oauth/token/introspect} endpoint.
+     */
+    @Deprecated
     public TokenIntrospect tokenIntrospect() {
         return this.post(this.configuration.getTokenIntrospect())
                 .send(new TypeReference<>() {});


### PR DESCRIPTION
Closes #20

Brings the OAuth surface in line with the current spec. Both endpoints live on the OAuth host (`https://id.kick.com`).

## Added
- **`AuthorizationClient.revokeToken(token[, hint])`** → `POST /oauth/revoke` (form-urlencoded, `token` + `token_hint_type` query params). New `TokenTypeHint` enum (`access_token`/`refresh_token`).
- **`AuthorizationClient.introspectToken([accessToken])`** → `POST /oauth/token/introspect` (Bearer auth). Introspects the managed access token by default, or a supplied one. Returns the reused `TokenIntrospect` model, parsed from the `{ data, message }` envelope.

## Changed
- **`UsersClient.tokenIntrospect()`** (old `/public/v1/token/introspect`) annotated `@Deprecated`, pointing to the relocated endpoint. Still functional.
- `KickConfiguration` gains configurable `revokeEndpoint` and `introspectEndpoint`.

## Note — parameter name discrepancy
The human docs (table + example) name the revoke hint param **`token_hint_type`**, while the OpenAPI spec calls it `token_type_hint` (the RFC 7009 name). I followed the docs (`token_hint_type`). Since the hint is optional and only an optimization, revocation works regardless; easy to flip if the server expects the RFC name.

## Tests
None — these are network-bound OAuth calls with no pure-logic surface to unit test here. `./gradlew clean build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)