### PR TITLE
Add Drops Public API client (and close out Organizations)

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/KickClient.java
+++ b/src/main/java/pl/teksusik/kick4j/KickClient.java
@@ -17,6 +17,7 @@ import pl.teksusik.kick4j.authorization.RefreshTokenStore;
 import pl.teksusik.kick4j.categories.CategoriesClient;
 import pl.teksusik.kick4j.channels.ChannelsClient;
 import pl.teksusik.kick4j.chat.ChatClient;
+import pl.teksusik.kick4j.drops.DropsClient;
 import pl.teksusik.kick4j.events.EventsClient;
 import pl.teksusik.kick4j.events.handler.BuiltInKickWebhookHandler;
 import pl.teksusik.kick4j.events.handler.KickEventDispatcher;
@@ -44,6 +45,7 @@ public class KickClient {
     private final KicksClient kicksClient;
     private final PublicKeyClient publicKeyClient;
     private final EventsClient eventsClient;
+    private final DropsClient dropsClient;
     private final KickSignatureVerifier signatureVerifier;
     private final KickEventDispatcher eventDispatcher;
 
@@ -84,6 +86,7 @@ public class KickClient {
         this.kicksClient = new KicksClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.publicKeyClient = new PublicKeyClient(httpClient, objectMapper, configuration, this.authorizationClient);
         this.eventsClient = new EventsClient(httpClient, objectMapper, configuration, this.authorizationClient);
+        this.dropsClient = new DropsClient(httpClient, objectMapper, configuration, this.authorizationClient);
 
         this.signatureVerifier = new KickSignatureVerifier(this.publicKeyClient);
         this.eventDispatcher = new KickEventDispatcher(objectMapper);
@@ -150,6 +153,10 @@ public class KickClient {
 
     public EventsClient events() {
         return eventsClient;
+    }
+
+    public DropsClient drops() {
+        return dropsClient;
     }
 
     public KickSignatureVerifier signatureVerifier() {

--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -35,6 +35,7 @@ public final class KickConfiguration {
     private final String channelsRewardsRedemptionsAccept;
     private final String channelsRewardsRedemptionsReject;
     private final String kicksLeaderboard;
+    private final String dropsClaims;
 
     private KickConfiguration(Builder builder) {
         this.tokenStore = builder.tokenStore;
@@ -67,6 +68,7 @@ public final class KickConfiguration {
         this.channelsRewardsRedemptionsAccept = builder.channelsRewardsRedemptionsAccept;
         this.channelsRewardsRedemptionsReject = builder.channelsRewardsRedemptionsReject;
         this.kicksLeaderboard = builder.kicksLeaderboard;
+        this.dropsClaims = builder.dropsClaims;
     }
 
     public static Builder builder() {
@@ -193,6 +195,10 @@ public final class KickConfiguration {
         return kicksLeaderboard;
     }
 
+    public String getDropsClaims() {
+        return dropsClaims;
+    }
+
     public static final class Builder {
         private RefreshTokenStore tokenStore;
         private String clientId;
@@ -224,6 +230,7 @@ public final class KickConfiguration {
         private String channelsRewardsRedemptionsAccept = "/channels/rewards/redemptions/accept";
         private String channelsRewardsRedemptionsReject = "/channels/rewards/redemptions/reject";
         private String kicksLeaderboard = "/kicks/leaderboard";
+        private String dropsClaims = "/drops/claims";
 
         public Builder tokenStore(RefreshTokenStore tokenStore) {
             this.tokenStore = tokenStore;
@@ -372,6 +379,11 @@ public final class KickConfiguration {
 
         public Builder kicksLeaderboard(String kicksLeaderboard) {
             this.kicksLeaderboard = kicksLeaderboard;
+            return this;
+        }
+
+        public Builder dropsClaims(String dropsClaims) {
+            this.dropsClaims = dropsClaims;
             return this;
         }
 

--- a/src/main/java/pl/teksusik/kick4j/drops/DropClaim.java
+++ b/src/main/java/pl/teksusik/kick4j/drops/DropClaim.java
@@ -1,0 +1,68 @@
+package pl.teksusik.kick4j.drops;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+
+public class DropClaim {
+    private final String claimId;
+    private final Integer userId;
+    private final String campaignId;
+    private final String rewardId;
+    private final String externalId;
+    private final String externalStatus;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    @JsonCreator
+    public DropClaim(@JsonProperty("claim_id") String claimId,
+                     @JsonProperty("user_id") Integer userId,
+                     @JsonProperty("campaign_id") String campaignId,
+                     @JsonProperty("reward_id") String rewardId,
+                     @JsonProperty("external_id") String externalId,
+                     @JsonProperty("external_status") String externalStatus,
+                     @JsonProperty("created_at") Instant createdAt,
+                     @JsonProperty("updated_at") Instant updatedAt) {
+        this.claimId = claimId;
+        this.userId = userId;
+        this.campaignId = campaignId;
+        this.rewardId = rewardId;
+        this.externalId = externalId;
+        this.externalStatus = externalStatus;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public String getClaimId() {
+        return claimId;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public String getCampaignId() {
+        return campaignId;
+    }
+
+    public String getRewardId() {
+        return rewardId;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getExternalStatus() {
+        return externalStatus;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/drops/DropClaimUpdate.java
+++ b/src/main/java/pl/teksusik/kick4j/drops/DropClaimUpdate.java
@@ -1,0 +1,26 @@
+package pl.teksusik.kick4j.drops;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A single claim status update for {@code PATCH /drops/claims}.
+ */
+public class DropClaimUpdate {
+    @JsonProperty("claim_id")
+    private final String claimId;
+    @JsonProperty("external_status")
+    private final String externalStatus;
+
+    public DropClaimUpdate(String claimId, String externalStatus) {
+        this.claimId = claimId;
+        this.externalStatus = externalStatus;
+    }
+
+    public String getClaimId() {
+        return claimId;
+    }
+
+    public String getExternalStatus() {
+        return externalStatus;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/drops/DropClaimsResponse.java
+++ b/src/main/java/pl/teksusik/kick4j/drops/DropClaimsResponse.java
@@ -1,0 +1,31 @@
+package pl.teksusik.kick4j.drops;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * A page of Drops reward claims. Unlike the generic paginated endpoints, the cursor
+ * is nested inside the {@code data} object; pass {@link #getCursor()} back as the
+ * {@code cursor} filter to fetch the next page.
+ */
+public class DropClaimsResponse {
+    private final List<DropClaim> claims;
+    private final String cursor;
+
+    @JsonCreator
+    public DropClaimsResponse(@JsonProperty("claims") List<DropClaim> claims,
+                              @JsonProperty("cursor") String cursor) {
+        this.claims = claims;
+        this.cursor = cursor;
+    }
+
+    public List<DropClaim> getClaims() {
+        return claims;
+    }
+
+    public String getCursor() {
+        return cursor;
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/drops/DropsClient.java
+++ b/src/main/java/pl/teksusik/kick4j/drops/DropsClient.java
@@ -1,0 +1,48 @@
+package pl.teksusik.kick4j.drops;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import pl.teksusik.kick4j.KickConfiguration;
+import pl.teksusik.kick4j.api.ApiClient;
+import pl.teksusik.kick4j.authorization.AuthorizationClient;
+
+import java.net.http.HttpClient;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Drops Public API. Only OAuth apps associated with an organization can access these
+ * endpoints (they require an app access token).
+ */
+public class DropsClient extends ApiClient {
+    public DropsClient(HttpClient httpClient, ObjectMapper mapper, KickConfiguration configuration, AuthorizationClient authorization) {
+        super(httpClient, mapper, configuration, authorization);
+    }
+
+    /**
+     * Retrieves Drops reward claims (first page, API default limit).
+     */
+    public DropClaimsResponse getClaims() {
+        return this.getClaims(GetDropClaimsRequest.builder().build());
+    }
+
+    /**
+     * Retrieves Drops reward claims using the provided filters. Page through results by
+     * passing {@link DropClaimsResponse#getCursor()} back as the request cursor.
+     */
+    public DropClaimsResponse getClaims(GetDropClaimsRequest request) {
+        return this.get(this.configuration.getDropsClaims())
+                .queryParams(request)
+                .send(new TypeReference<>() {});
+    }
+
+    /**
+     * Updates the {@code external_status} of one or more claims (up to 100 per request).
+     * Returns on 204 No Content.
+     */
+    public void updateClaims(List<DropClaimUpdate> claims) {
+        this.patch(this.configuration.getDropsClaims())
+                .body(Map.of("claims", claims))
+                .send(new TypeReference<>() {});
+    }
+}

--- a/src/main/java/pl/teksusik/kick4j/drops/GetDropClaimsRequest.java
+++ b/src/main/java/pl/teksusik/kick4j/drops/GetDropClaimsRequest.java
@@ -1,0 +1,104 @@
+package pl.teksusik.kick4j.drops;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Filters for {@code GET /drops/claims}. All fields are optional.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetDropClaimsRequest {
+    @JsonProperty("campaign_id")
+    private final String campaignId;
+    @JsonProperty("limit")
+    private final Integer limit;
+    @JsonProperty("cursor")
+    private final String cursor;
+    @JsonProperty("user_id")
+    private final Integer userId;
+    @JsonProperty("claim_id")
+    private final String claimId;
+    @JsonProperty("external_status")
+    private final String externalStatus;
+
+    public GetDropClaimsRequest(String campaignId, Integer limit, String cursor, Integer userId,
+                                String claimId, String externalStatus) {
+        this.campaignId = campaignId;
+        this.limit = limit;
+        this.cursor = cursor;
+        this.userId = userId;
+        this.claimId = claimId;
+        this.externalStatus = externalStatus;
+    }
+
+    public String getCampaignId() {
+        return campaignId;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public String getCursor() {
+        return cursor;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public String getClaimId() {
+        return claimId;
+    }
+
+    public String getExternalStatus() {
+        return externalStatus;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String campaignId;
+        private Integer limit;
+        private String cursor;
+        private Integer userId;
+        private String claimId;
+        private String externalStatus;
+
+        public Builder campaignId(String campaignId) {
+            this.campaignId = campaignId;
+            return this;
+        }
+
+        public Builder limit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public Builder cursor(String cursor) {
+            this.cursor = cursor;
+            return this;
+        }
+
+        public Builder userId(Integer userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder claimId(String claimId) {
+            this.claimId = claimId;
+            return this;
+        }
+
+        public Builder externalStatus(String externalStatus) {
+            this.externalStatus = externalStatus;
+            return this;
+        }
+
+        public GetDropClaimsRequest build() {
+            return new GetDropClaimsRequest(campaignId, limit, cursor, userId, claimId, externalStatus);
+        }
+    }
+}


### PR DESCRIPTION
Closes #21

Final full-coverage pass.

## Drops Public API — implemented
New `DropsClient` (via `kick.drops()`) for the Drops reward-claims endpoints. These require an OAuth **app** access token from an org-associated app.

- **GET `/drops/claims`** — filters `campaign_id`, `limit` (default 10, max 1000), `cursor`, `user_id`, `claim_id`, `external_status` → `DropClaimsResponse`.
- **PATCH `/drops/claims`** — update `external_status` for up to 100 claims → 204.

Models: `DropClaim` (`claim_id`, `user_id`, `campaign_id`, `reward_id`, `external_id`, `external_status`, `created_at`, `updated_at`), `DropClaimsResponse` (`claims` + nested `cursor`), `DropClaimUpdate`, `GetDropClaimsRequest`.

> **Pagination note:** this endpoint nests the cursor **inside** `data` (`data.cursor`) rather than as a sibling `pagination` object, so it uses a dedicated `DropClaimsResponse` instead of the generic `PaginatedResponse`. Pass `getCursor()` back as the `cursor` filter to page.

## Organizations — no code (documented finding)
Per `organizations/organization-management.md`, organization management has **no public REST API** — registration is by emailing `developers@kick.com` and members are managed via the dashboard. There is nothing to implement, so no client was added. Recorded here so the coverage gap is intentional and explained.

## Tests
None — `DropClaim`/`DropClaimsResponse` are response DTOs without a full documented payload beyond the field list; `GetDropClaimsRequest` uses the existing query-param path. `./gradlew clean build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)