### PR TITLE
Support app access token (Client Credentials) with an explicit AuthMode

### DIFF
--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -1,5 +1,6 @@
 package pl.teksusik.kick4j;
 
+import pl.teksusik.kick4j.authorization.AuthMode;
 import pl.teksusik.kick4j.authorization.RefreshTokenStore;
 
 public final class KickConfiguration {
@@ -16,7 +17,7 @@ public final class KickConfiguration {
     private final String introspectEndpoint;
     private final String baseUrl;
     private final String baseUrlV2;
-    private final boolean defaultAppAuth;
+    private final AuthMode authMode;
     private final String categories;
     private final String categoriesId;
     private final String tokenIntrospect;
@@ -50,7 +51,7 @@ public final class KickConfiguration {
         this.introspectEndpoint = builder.introspectEndpoint;
         this.baseUrl = builder.baseUrl;
         this.baseUrlV2 = builder.baseUrlV2;
-        this.defaultAppAuth = builder.defaultAppAuth;
+        this.authMode = builder.authMode;
         this.categories = builder.categories;
         this.categoriesId = builder.categoriesId;
         this.tokenIntrospect = builder.tokenIntrospect;
@@ -122,11 +123,11 @@ public final class KickConfiguration {
     }
 
     /**
-     * Whether requests use an app access token (Client Credentials flow) by default,
-     * instead of the user access token. Individual requests can still override this.
+     * The default token type used to authenticate requests. Individual requests can still
+     * override this.
      */
-    public boolean isDefaultAppAuth() {
-        return defaultAppAuth;
+    public AuthMode getAuthMode() {
+        return authMode;
     }
 
     public String getCategories() {
@@ -221,7 +222,7 @@ public final class KickConfiguration {
         private String introspectEndpoint = "/oauth/token/introspect";
         private String baseUrl = "https://api.kick.com/public/v1";
         private String baseUrlV2 = "https://api.kick.com/public/v2";
-        private boolean defaultAppAuth = false;
+        private AuthMode authMode;
         private String categories = "/categories";
         private String categoriesId = "/categories/{id}";
         private String tokenIntrospect = "/token/introspect";
@@ -299,12 +300,13 @@ public final class KickConfiguration {
         }
 
         /**
-         * Makes every request default to an app access token (Client Credentials flow)
-         * instead of the user access token. Ideal for server-to-server / app-only usage.
+         * The default token type used to authenticate requests (required).
+         * Use {@link AuthMode#APP} for server-to-server / app-only usage or
+         * {@link AuthMode#USER} for acting on behalf of a logged-in user.
          * Individual requests may still override this per call.
          */
-        public Builder defaultAppAuth(boolean defaultAppAuth) {
-            this.defaultAppAuth = defaultAppAuth;
+        public Builder authMode(AuthMode authMode) {
+            this.authMode = authMode;
             return this;
         }
 
@@ -418,6 +420,10 @@ public final class KickConfiguration {
 
             if (clientSecret == null) {
                 throw new IllegalStateException("ClientSecret is required");
+            }
+
+            if (authMode == null) {
+                throw new IllegalStateException("AuthMode is required (AuthMode.APP or AuthMode.USER)");
             }
 
             return new KickConfiguration(this);

--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -16,6 +16,7 @@ public final class KickConfiguration {
     private final String introspectEndpoint;
     private final String baseUrl;
     private final String baseUrlV2;
+    private final boolean defaultAppAuth;
     private final String categories;
     private final String categoriesId;
     private final String tokenIntrospect;
@@ -49,6 +50,7 @@ public final class KickConfiguration {
         this.introspectEndpoint = builder.introspectEndpoint;
         this.baseUrl = builder.baseUrl;
         this.baseUrlV2 = builder.baseUrlV2;
+        this.defaultAppAuth = builder.defaultAppAuth;
         this.categories = builder.categories;
         this.categoriesId = builder.categoriesId;
         this.tokenIntrospect = builder.tokenIntrospect;
@@ -117,6 +119,14 @@ public final class KickConfiguration {
 
     public String getBaseUrlV2() {
         return baseUrlV2;
+    }
+
+    /**
+     * Whether requests use an app access token (Client Credentials flow) by default,
+     * instead of the user access token. Individual requests can still override this.
+     */
+    public boolean isDefaultAppAuth() {
+        return defaultAppAuth;
     }
 
     public String getCategories() {
@@ -211,6 +221,7 @@ public final class KickConfiguration {
         private String introspectEndpoint = "/oauth/token/introspect";
         private String baseUrl = "https://api.kick.com/public/v1";
         private String baseUrlV2 = "https://api.kick.com/public/v2";
+        private boolean defaultAppAuth = false;
         private String categories = "/categories";
         private String categoriesId = "/categories/{id}";
         private String tokenIntrospect = "/token/introspect";
@@ -284,6 +295,16 @@ public final class KickConfiguration {
 
         public Builder baseUrlV2(String baseUrlV2) {
             this.baseUrlV2 = baseUrlV2;
+            return this;
+        }
+
+        /**
+         * Makes every request default to an app access token (Client Credentials flow)
+         * instead of the user access token. Ideal for server-to-server / app-only usage.
+         * Individual requests may still override this per call.
+         */
+        public Builder defaultAppAuth(boolean defaultAppAuth) {
+            this.defaultAppAuth = defaultAppAuth;
             return this;
         }
 

--- a/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
+++ b/src/main/java/pl/teksusik/kick4j/KickConfiguration.java
@@ -409,20 +409,15 @@ public final class KickConfiguration {
         }
 
         public KickConfiguration build() {
-            if (tokenStore == null) {
-                throw new IllegalStateException("TokenStore is required");
-            }
-
+            // clientId and clientSecret are needed for every flow (including app auth).
+            // redirectUri and tokenStore are only used by the user authorization flow and
+            // are validated lazily where they are used, so an app-only setup can omit them.
             if (clientId == null) {
                 throw new IllegalStateException("ClientId is required");
             }
 
             if (clientSecret == null) {
                 throw new IllegalStateException("ClientSecret is required");
-            }
-
-            if (redirectUri == null) {
-                throw new IllegalStateException("RedirectUri is required");
             }
 
             return new KickConfiguration(this);

--- a/src/main/java/pl/teksusik/kick4j/api/ApiClient.java
+++ b/src/main/java/pl/teksusik/kick4j/api/ApiClient.java
@@ -59,6 +59,7 @@ public abstract class ApiClient {
             this.method = method;
             this.path = path;
             this.baseUrl = configuration.getBaseUrl();
+            this.appAuth = configuration.isDefaultAppAuth();
         }
 
         /**
@@ -75,6 +76,15 @@ public abstract class ApiClient {
          */
         public RequestBuilder appAuth() {
             this.appAuth = true;
+            return this;
+        }
+
+        /**
+         * Authenticates this request with the user access token, overriding a configured
+         * {@link KickConfiguration#isDefaultAppAuth() app-auth default} for this call.
+         */
+        public RequestBuilder userAuth() {
+            this.appAuth = false;
             return this;
         }
 

--- a/src/main/java/pl/teksusik/kick4j/api/ApiClient.java
+++ b/src/main/java/pl/teksusik/kick4j/api/ApiClient.java
@@ -50,6 +50,7 @@ public abstract class ApiClient {
         private final String method;
         private String path;
         private String baseUrl;
+        private boolean appAuth;
         private Map<String, Object> queryParams;
         private Object bodyObject;
         private Class<?> bodyClass;
@@ -65,6 +66,15 @@ public abstract class ApiClient {
          */
         public RequestBuilder baseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * Authenticates this request with an app access token (Client Credentials flow)
+         * instead of the user access token. Use for endpoints that require an app token.
+         */
+        public RequestBuilder appAuth() {
+            this.appAuth = true;
             return this;
         }
 
@@ -106,9 +116,10 @@ public abstract class ApiClient {
 
         private HttpResponse<String> execute() throws IOException, InterruptedException {
             String url = buildUrl(this.baseUrl + this.path, this.queryParams);
+            String accessToken = this.appAuth ? authorization.getAppAccessToken() : authorization.getAccessToken();
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(url))
-                    .header("Authorization", "Bearer " + authorization.getAccessToken())
+                    .header("Authorization", "Bearer " + accessToken)
                     .header("Accept", "application/json");
 
             if ("GET".equalsIgnoreCase(method)) {

--- a/src/main/java/pl/teksusik/kick4j/api/ApiClient.java
+++ b/src/main/java/pl/teksusik/kick4j/api/ApiClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import pl.teksusik.kick4j.KickConfiguration;
+import pl.teksusik.kick4j.authorization.AuthMode;
 import pl.teksusik.kick4j.authorization.AuthorizationClient;
 
 import java.io.IOException;
@@ -59,7 +60,7 @@ public abstract class ApiClient {
             this.method = method;
             this.path = path;
             this.baseUrl = configuration.getBaseUrl();
-            this.appAuth = configuration.isDefaultAppAuth();
+            this.appAuth = configuration.getAuthMode() == AuthMode.APP;
         }
 
         /**
@@ -80,8 +81,8 @@ public abstract class ApiClient {
         }
 
         /**
-         * Authenticates this request with the user access token, overriding a configured
-         * {@link KickConfiguration#isDefaultAppAuth() app-auth default} for this call.
+         * Authenticates this request with the user access token, overriding the configured
+         * {@link KickConfiguration#getAuthMode() default auth mode} for this call.
          */
         public RequestBuilder userAuth() {
             this.appAuth = false;

--- a/src/main/java/pl/teksusik/kick4j/authorization/AuthMode.java
+++ b/src/main/java/pl/teksusik/kick4j/authorization/AuthMode.java
@@ -1,0 +1,17 @@
+package pl.teksusik.kick4j.authorization;
+
+/**
+ * The default token type used to authenticate API requests.
+ *
+ * <ul>
+ *   <li>{@link #USER} — user access token (Authorization Code + PKCE flow); required for
+ *       actions on behalf of a user (chat, moderation, channel updates, per-user events).</li>
+ *   <li>{@link #APP} — app access token (Client Credentials flow); server-to-server access
+ *       to publicly available data, no user login required.</li>
+ * </ul>
+ *
+ * Individual requests may still override the configured mode.
+ */
+public enum AuthMode {
+    USER, APP
+}

--- a/src/main/java/pl/teksusik/kick4j/authorization/AuthorizationClient.java
+++ b/src/main/java/pl/teksusik/kick4j/authorization/AuthorizationClient.java
@@ -38,6 +38,9 @@ public class AuthorizationClient {
     private String accessToken;
     private Instant expiresAt;
 
+    private String appAccessToken;
+    private Instant appExpiresAt;
+
     /**
      * Creates a new AuthorizationClient.
      *
@@ -144,6 +147,41 @@ public class AuthorizationClient {
         OAuthTokenResponse newToken = this.postOAuthTokenRequest(body);
         this.refreshToken.notifyRefreshTokenRoll(newToken.getRefreshToken());
         return newToken;
+    }
+
+    /**
+     * Requests a fresh app access token using the OAuth 2.1 Client Credentials flow
+     * ({@code grant_type=client_credentials}). App tokens are server-to-server tokens for
+     * accessing publicly available data and do not require a user login. They carry no
+     * refresh token; a new one is requested on demand once the current token expires.
+     *
+     * @return the new app access token response
+     */
+    public OAuthTokenResponse requestAppAccessToken() {
+        Map<String, String> body = Map.of(
+                "grant_type", "client_credentials",
+                "client_id", this.configuration.getClientId(),
+                "client_secret", this.configuration.getClientSecret()
+        );
+
+        OAuthTokenResponse response = this.postOAuthTokenRequest(body);
+        this.appAccessToken = response.getAccessToken();
+        this.appExpiresAt = Instant.now().plusSeconds(response.getExpiresIn());
+        return response;
+    }
+
+    /**
+     * Returns a valid app access token, requesting a new one via the Client Credentials
+     * flow if the current one is missing or about to expire.
+     *
+     * @return a valid app access token string
+     */
+    public String getAppAccessToken() {
+        if (this.appAccessToken == null || Instant.now().isAfter(this.appExpiresAt.minusSeconds(10))) {
+            this.requestAppAccessToken();
+        }
+
+        return this.appAccessToken;
     }
 
     /**

--- a/src/main/java/pl/teksusik/kick4j/authorization/AuthorizationClient.java
+++ b/src/main/java/pl/teksusik/kick4j/authorization/AuthorizationClient.java
@@ -92,6 +92,7 @@ public class AuthorizationClient {
      * @return the full URL string for the authorization request
      */
     public String getAuthorizationUrl(List<Scope> scopeList, String codeChallenge) {
+        this.requireRedirectUri();
         StringJoiner joiner = new StringJoiner("&",
                 this.configuration.getOAuthHost() + this.configuration.getAuthorizationEndpoint() + "?",
                 "");
@@ -119,6 +120,7 @@ public class AuthorizationClient {
      * @return an OAuthTokenResponse containing access and refresh tokens
      */
     public OAuthTokenResponse exchangeCodeForToken(String code, String codeVerifier) {
+        this.requireRedirectUri();
         Map<String, String> body = Map.of(
                 "code", code,
                 "client_id", this.configuration.getClientId(),
@@ -137,6 +139,7 @@ public class AuthorizationClient {
      * @return a new OAuthTokenResponse containing refreshed access and refresh tokens
      */
     public OAuthTokenResponse refreshAccessToken() {
+        this.requireTokenStore();
         Map<String, String> body = Map.of(
                 "refresh_token", this.refreshToken.getRefreshToken(),
                 "client_id", this.configuration.getClientId(),
@@ -285,9 +288,22 @@ public class AuthorizationClient {
      * @param oAuthToken the OAuthTokenResponse containing the new tokens and expiry
      */
     public void setTokens(OAuthTokenResponse oAuthToken) {
+        this.requireTokenStore();
         this.accessToken = oAuthToken.getAccessToken();
         this.refreshToken.notifyRefreshTokenRoll(oAuthToken.getRefreshToken());
         this.expiresAt = Instant.now().plusSeconds(oAuthToken.getExpiresIn());
+    }
+
+    private void requireRedirectUri() {
+        if (this.configuration.getRedirectUri() == null) {
+            throw new IllegalStateException("RedirectUri is required for the user authorization flow");
+        }
+    }
+
+    private void requireTokenStore() {
+        if (this.refreshToken == null) {
+            throw new IllegalStateException("TokenStore is required for the user authorization flow");
+        }
     }
 
     /**

--- a/src/main/java/pl/teksusik/kick4j/drops/DropsClient.java
+++ b/src/main/java/pl/teksusik/kick4j/drops/DropsClient.java
@@ -32,6 +32,7 @@ public class DropsClient extends ApiClient {
      */
     public DropClaimsResponse getClaims(GetDropClaimsRequest request) {
         return this.get(this.configuration.getDropsClaims())
+                .appAuth()
                 .queryParams(request)
                 .send(new TypeReference<>() {});
     }
@@ -42,6 +43,7 @@ public class DropsClient extends ApiClient {
      */
     public void updateClaims(List<DropClaimUpdate> claims) {
         this.patch(this.configuration.getDropsClaims())
+                .appAuth()
                 .body(Map.of("claims", claims))
                 .send(new TypeReference<>() {});
     }


### PR DESCRIPTION
Adds the **App Access Token** (Client Credentials) flow so app-only, server-to-server usage works without a user login — and makes the token type an explicit, required choice.

## Auth mode (required)
`KickConfiguration.builder()` now requires **`.authMode(AuthMode.APP | AuthMode.USER)`** and fails fast otherwise, so a request never silently uses the wrong token type.

```java
// app-only (server-to-server)
KickConfiguration.builder()
    .clientId("...")
    .clientSecret("...")
    .authMode(AuthMode.APP)
    .build();                 // no redirectUri / tokenStore needed
```

- `ApiClient` defaults each request's token to the configured mode; `appAuth()` / `userAuth()` override per request.
- `DropsClient` always forces `appAuth()` (the Drops API requires an app token) regardless of the configured mode.

## Client Credentials flow
- `AuthorizationClient.requestAppAccessToken()` → `POST /oauth/token` with `grant_type=client_credentials` (`client_id` + `client_secret`); caches token + expiry.
- `AuthorizationClient.getAppAccessToken()` → returns a valid app token, auto-renewing on expiry (app tokens carry no refresh token).

## Relaxed config validation
`build()` now requires only `clientId`, `clientSecret` and `authMode`. `redirectUri` and `tokenStore` are used solely by the user flow and are validated **lazily** where used (with clear messages), so an app-only client needs neither.

## Breaking change
`KickConfiguration.builder()` now requires `.authMode(...)`. Existing code must add it (`AuthMode.USER` reproduces the previous default behaviour).

## Tests
None — network-bound token exchange / config plumbing. `./gradlew clean build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)